### PR TITLE
Add extras model JobResults

### DIFF
--- a/pynautobot/models/extras.py
+++ b/pynautobot/models/extras.py
@@ -32,3 +32,7 @@ class ObjectChanges(Record):
 class CustomFieldChoices(Record):
     def __str__(self):
         return self.value
+
+class JobResults(Record):
+    data = JsonField
+

--- a/pynautobot/models/extras.py
+++ b/pynautobot/models/extras.py
@@ -33,6 +33,7 @@ class CustomFieldChoices(Record):
     def __str__(self):
         return self.value
 
+
 class JobResults(Record):
     data = JsonField
 

--- a/pynautobot/models/extras.py
+++ b/pynautobot/models/extras.py
@@ -36,4 +36,3 @@ class CustomFieldChoices(Record):
 
 class JobResults(Record):
     data = JsonField
-


### PR DESCRIPTION
Currently the data field for JobResults is None. Adding the `JobResults` class and defining the `data` attribute to use JsonField will make this field properly serialize the data as JSON.