### PR TITLE
Properly Create nat_inside/outside Record objects

### DIFF
--- a/.bandit.yml
+++ b/.bandit.yml
@@ -3,3 +3,4 @@ skips: []
 # No need to check for security issues in the test scripts!
 exclude_dirs:
   - "./tests/"
+  - "./.devicetype-library/"

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ Dockerfile
 docker-compose.yml
 .env
 docs/_build
+.devicetype-library

--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@
 # W503: Black disagrees with this rule, as does PEP 8; Black wins
 # E203: Black disagrees with this rule; Black wins
 ignore = E501, W503, E203
+exclude = .devicetype-library

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   # - invoke build-image --nocache
   - "pip3 install poetry"
   - "poetry install"
-  - "invoke start"
+  - "poetry run invoke start"
   - timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8000)" != "200" ]]; do echo "waiting for Nautobot"; sleep 5; done' || false # yamllint disable-line rule:quoted-strings
 
 script:
@@ -36,11 +36,9 @@ script:
 
 jobs:
   include:
-    - stage: "lint"
-      before_script:
-        - "pip install black==19.10b0"
+    - stage: "tests"
       script:
-        - "black --diff --check ."
+        - "INVOKE_LOCAL=true poetry run invoke tests"
 
     - stage: "deploy-github"
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 ---
 stages:
-  - lint
-  - test
+  - "lint"
+  - "test"
   - name: "deploy-github"
     if: "tag IS present"
   - name: "deploy-pypi"
     if: "tag IS present"
 
-language: python
+language: "python"
 services:
   - "docker"
 
@@ -26,21 +26,21 @@ before_script:
   # To be added later
   # - pip install invoke poetry toml
   # - invoke build-image --nocache
-  - pip3 install poetry
-  - poetry install
-  - invoke start
-  - timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8000)" != "200" ]]; do echo "waiting for Nautobot"; sleep 5; done' || false
+  - "pip3 install poetry"
+  - "poetry install"
+  - "invoke start"
+  - timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8000)" != "200" ]]; do echo "waiting for Nautobot"; sleep 5; done' || false # yamllint disable-line rule:quoted-strings
 
 script:
-  - pytest -v
+  - "pytest -v"
 
 jobs:
   include:
-    - stage: lint
+    - stage: "lint"
       before_script:
-        - pip install black==19.10b0
+        - "pip install black==19.10b0"
       script:
-        - black --diff --check .
+        - "black --diff --check ."
 
     - stage: "deploy-github"
       before_script:
@@ -54,7 +54,7 @@ jobs:
         file_glob: true
         file: "dist/*"
         skip_cleanup: true
-        on:
+        on: # yamllint disable-line rule:truthy
           all_branches: true
 
     - stage: "deploy-pypi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ services:
 env:
   matrix:
     - PYTHON_VER: "3.6"
-      NAUTOBOT_VER: "1.0.3"
+      NAUTOBOT_VER: "1.1.6"
     - PYTHON_VER: "3.7"
-      NAUTOBOT_VER: "1.0.3"
+      NAUTOBOT_VER: "1.2"
     - PYTHON_VER: "3.8"
-      NAUTOBOT_VER: "1.0.3"
+      NAUTOBOT_VER: "1.2"
     - PYTHON_VER: "3.9"
-      NAUTOBOT_VER: "1.0.3"
+      NAUTOBOT_VER: "1.3"
 
 before_script:
   # To be added later

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -8,3 +8,5 @@ rules:
   line-length: "disable"
   quoted-strings:
     quote-type: "double"
+ignore: |
+  .devicetype-library

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 version: "3"
 services:
   nautobot:
@@ -27,6 +28,6 @@ services:
     image: "redis:6-alpine"
     command:
       - "sh"
-      - "-c"  # this is to evaluate the $REDIS_PASSWORD from the env
-      - "redis-server --appendonly yes --requirepass $$REDIS_PASSWORD"  ## $$ because of docker-compose
+      - "-c" # this is to evaluate the $REDIS_PASSWORD from the env
+      - "redis-server --appendonly yes --requirepass $$REDIS_PASSWORD" ## $$ because of docker-compose
     env_file: "./dev.env"

--- a/pynautobot/core/api.py
+++ b/pynautobot/core/api.py
@@ -15,8 +15,6 @@ limitations under the License.
 
 This file has been modified by NetworktoCode, LLC.
 """
-import sys
-
 import requests
 
 from pynautobot.core.query import Request

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -70,7 +70,7 @@ class Endpoint(object):
         :Returns: Record (obj)
         """
         if model:
-            name = name.title().replace("_", "")
+            name = name.title().replace("_", "").replace("-", "")
             ret = getattr(model, name, Record)
         else:
             ret = Record

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -80,8 +80,8 @@ class Endpoint(object):
         """Queries the 'ListView' of a given endpoint.
 
         Returns all objects from an endpoint.
-        
-        :arg str,optional api_version: Override default or globally-set Nautobot REST API 
+
+        :arg str,optional api_version: Override default or globally-set Nautobot REST API
             version for this single request.
 
         :Returns: List of :py:class:`.Record` objects.
@@ -113,8 +113,8 @@ class Endpoint(object):
         :arg str,optional \**kwargs: Accepts the same keyword args as
             filter(). Any search argument the endpoint accepts can
             be added as a keyword arg.
-        
-        :arg str,optional api_version: Override default or globally-set Nautobot REST API 
+
+        :arg str,optional api_version: Override default or globally-set Nautobot REST API
             version for this single request.
 
         :returns: A single :py:class:`.Record` object or None
@@ -182,7 +182,7 @@ class Endpoint(object):
             accepted on given endpoint.
         :arg str,optional \**kwargs: Any search argument the
             endpoint accepts can be added as a keyword arg.
-        :arg str,optional api_version: Override default or globally-set 
+        :arg str,optional api_version: Override default or globally-set
             Nautobot REST API version for this single request.
 
         :Returns: A list of :py:class:`.Record` objects.
@@ -251,7 +251,7 @@ class Endpoint(object):
             properties of the objects to be created.
         :arg str \**kwargs: key/value strings representing
             properties on a json object.
-        :arg str,optional api_version: Override default or globally-set 
+        :arg str,optional api_version: Override default or globally-set
             Nautobot REST API version for this single request.
 
         :returns: A list or single :py:class:`.Record` object depending
@@ -304,8 +304,8 @@ class Endpoint(object):
         without recurring requests to Nautobot. When using ``.choices()`` in
         long-running applications, consider restarting them whenever Nautobot is
         upgraded, to prevent using stale choices data.
-        
-        :arg str,optional api_version: Override default or globally-set 
+
+        :arg str,optional api_version: Override default or globally-set
             Nautobot REST API version for this single request.
 
         :Returns: Dict containing the available choices.
@@ -360,7 +360,7 @@ class Endpoint(object):
             accepted on given endpoint.
         :arg str,optional \**kwargs: Any search argument the
             endpoint accepts can be added as a keyword arg.
-        :arg str,optional api_version: Override default or globally-set 
+        :arg str,optional api_version: Override default or globally-set
             Nautobot REST API version for this single request.
 
         :Returns: Integer with count of objects returns by query.
@@ -439,7 +439,7 @@ class DetailEndpoint(object):
             key/value pair of the items you're creating on the parent
             object. Defaults to empty dict which will create a single
             item with default values.
-        :args str,optional api_version: Override default or globally set 
+        :args str,optional api_version: Override default or globally set
             Nautobot REST API version for this single request.
 
         :returns: A dictionary or list of dictionaries its created in

--- a/pynautobot/core/graphql.py
+++ b/pynautobot/core/graphql.py
@@ -1,5 +1,5 @@
 """GraphQL endpoint for making queries to the Nautobot GraphQL endpoint."""
-from typing import Optional, Dict, Iterable, Any
+from typing import Optional, Dict, Any
 
 
 class GraphQLException(Exception):

--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -168,8 +168,13 @@ class Record(object):
         self._full_cache = []
         self._init_cache = []
         self.api = api
-        self.endpoint = self._endpoint_from_url(values["url"]) if values and "url" in values else endpoint
-        self.default_ret = self.endpoint.return_obj or endpoint
+        self.default_ret = Record
+        self.endpoint = self._endpoint_from_url(values["url"]) if "url" in values else endpoint
+
+        # Return a custom Record if available on the endpoint (IpAddresses)
+        if self.endpoint and self.endpoint.return_obj:
+            self.default_ret = self.endpoint.return_obj
+
         if values:
             self._parse_values(values)
 

--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -25,7 +25,7 @@ from pynautobot.core.util import Hashabledict
 
 
 # List of fields that are lists but should be treated as sets.
-LIST_AS_SET = ("tags", "tagged_vlans")
+LIST_AS_SET = ("tags", "tagged_vlans", "nat_outside")
 
 
 def get_return(lookup, return_fields=None):
@@ -168,8 +168,8 @@ class Record(object):
         self._full_cache = []
         self._init_cache = []
         self.api = api
-        self.default_ret = Record
         self.endpoint = self._endpoint_from_url(values["url"]) if values and "url" in values else endpoint
+        self.default_ret = self.endpoint.return_obj or endpoint
         if values:
             self._parse_values(values)
 

--- a/tasks.py
+++ b/tasks.py
@@ -241,6 +241,6 @@ def tests(context, local=INVOKE_LOCAL):
     # pydocstyle(context, local)
     bandit(context, local)
     # Skipping due to some issues, but at least linting, etc. is working
-    # pytest(context, local)
+    pytest(context, local)
 
     print("All tests have passed!")

--- a/tests/integration/test_ipam.py
+++ b/tests/integration/test_ipam.py
@@ -1,0 +1,14 @@
+from pynautobot.models.ipam import IpAddresses
+
+
+def test_ip_address_nat_inside_outside_correct_objects(nb_client):
+    """Validate nat_inside and nat_outside both return IpAddress Record objects."""
+    ip_inside = nb_client.ipam.ip_addresses.create(address="192.0.2.1/32", status="active")
+    ip_outside = nb_client.ipam.ip_addresses.create(address="192.0.2.2/32", status="active", nat_inside=ip_inside.id)
+
+    ip_inside_refresh = nb_client.ipam.ip_addresses.get(address="192.0.2.1/32")
+
+    assert isinstance(ip_outside.nat_inside, IpAddresses)
+    assert isinstance(ip_inside_refresh.nat_outside, IpAddresses)
+    assert str(ip_outside.nat_inside) == "192.0.2.1/32"
+    assert str(ip_inside_refresh.nat_outside) == "192.0.2.2/32"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,6 @@ import unittest
 import six
 
 import pynautobot
-from .util import Response
 
 if six.PY3:
     from unittest.mock import patch

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -204,9 +204,6 @@ query ($device: String!) {
             "status_code": 200,
         }
     ]
-    expected_response = {
-        "data": {"devices": [{"name": "grb-rtr01", "id": 1, "primary_ip4": {"address": "192.0.2.10/32"}}]}
-    }
     with requests_mock.Mocker() as mock:
         load_api_calls(mock, api_calls)
         with pytest.raises(TypeError) as err:
@@ -240,7 +237,7 @@ query ($device: String!) {
     expected_response = {"data": {"devices": []}}
     with requests_mock.Mocker() as mock:
         load_api_calls(mock, api_calls)
-        query_result = graphql_test_class.query(query=query_str, variables=None)
+        query_result = graphql_test_class.query(query=query_str, variables=variables)
 
     assert isinstance(query_result, GraphQLRecord)
     assert query_result.json == expected_response
@@ -295,7 +292,7 @@ query {
         err.value.body
         == b'{"query": "\\nquery {\\n  test {\\n    name\\n    id\\n    primary_ip4 {\\n      address\\n    }\\n  }\\n}\\n", "variables": null}'
     )
-    assert err.value.reason == None
+    assert err.value.reason is None
     assert err.value.json == expected_response
 
 
@@ -358,5 +355,5 @@ query {
     assert err.value.body == (
         b'{"query": "\\nquery {\\n  devices {\\n    nae\\n    id\\n    primary_ip4 {\\n        address\\n    }\\n  }\\n  sites {\\n    nme\\n    id\\n  }\\n}\\n", "variables": null}'
     )
-    assert err.value.reason == None
+    assert err.value.reason is None
     assert err.value.json == expected_response

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -3,6 +3,9 @@ import unittest
 import six
 
 from pynautobot.core.response import Record
+from pynautobot.core.endpoint import Endpoint
+from pynautobot.models.ipam import IpAddresses
+from pynautobot.core.app import App
 
 if six.PY3:
     from unittest.mock import Mock
@@ -213,6 +216,7 @@ class RecordTestCase(unittest.TestCase):
         app.base_url = "http://localhost:8080/api"
         endpoint = Mock()
         endpoint.name = "test-endpoint"
+        endpoint.return_obj = Record
         test = Record(
             {
                 "id": 123,
@@ -238,6 +242,7 @@ class RecordTestCase(unittest.TestCase):
         app.base_url = "http://localhost:8080/testing/api"
         endpoint = Mock()
         endpoint.name = "test-endpoint"
+        endpoint.return_obj = Record
         test = Record(
             {
                 "id": 123,
@@ -320,3 +325,14 @@ class RecordTestCase(unittest.TestCase):
         ]
         test = Record({"id": 123, "tags": test_tags}, None, None).serialize()
         self.assertEqual(test["tags"], test_tags)
+
+    def test_custom_return_object_ip_addresses(self):
+        """Validate the proper default_ret is provided for IpAddresses custom record."""
+        api = Mock()
+        api.base_url = "http://localhost:8080/api"
+        app = App(api, "ipam")
+        endpoint = Endpoint(api, app, "ip_addresses")
+        test = Record(
+            {"id": 123, "name": "test", "url": "http://localhost:8080/api/ipam/ip-addresses/1/"}, api, endpoint,
+        )
+        assert test.default_ret == IpAddresses


### PR DESCRIPTION
The actual issue was the __str__ for the base `Record` object looks for name or label which doesn't exist on an IPAddress.

This change returns the proper Record object now that has the appropriate __str__ method.