### PR TITLE
Changed __str__ to use the display field as it is on all models.

### DIFF
--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -210,7 +210,7 @@ class Record(object):
         return dict(self)[k]
 
     def __str__(self):
-        return getattr(self, "name", None) or getattr(self, "label", None) or ""
+        return getattr(self, "display", "")
 
     def __repr__(self):
         return str(self)

--- a/tests/integration/test_dcim.py
+++ b/tests/integration/test_dcim.py
@@ -125,8 +125,9 @@ class TestSimpleServerRackingAndConnecting:
         # check that it's racked properly
         assert server.rack.id == rack.id
 
-    def test_string_represention(self, nb_client, site):
+    def test_string_represention(self, nb_client):
         """Validate two device objects return the proper string when casting to string."""
+        site = nb_client.dcim.sites.get(slug="msp")
         device_no_name = nb_client.dcim.devices.create(
             device_type={"slug": "dcs-7050tx3-48c8"},
             device_role={"name": "Leaf Switch"},

--- a/tests/integration/test_dcim.py
+++ b/tests/integration/test_dcim.py
@@ -124,3 +124,21 @@ class TestSimpleServerRackingAndConnecting:
 
         # check that it's racked properly
         assert server.rack.id == rack.id
+
+    def test_string_represention(self, nb_client, site):
+        """Validate two device objects return the proper string when casting to string."""
+        device_no_name = nb_client.dcim.devices.create(
+            device_type={"slug": "dcs-7050tx3-48c8"},
+            device_role={"name": "Leaf Switch"},
+            site=site.id,
+            status="active",
+        )
+        device_w_name = nb_client.dcim.devices.create(
+            name="im a real boy",
+            device_type={"slug": "dcs-7050tx3-48c8"},
+            device_role={"name": "Leaf Switch"},
+            site=site.id,
+            status="active",
+        )
+        assert str(device_no_name) == f"Arista dcs-7050tx3-48c8 ({device_no_name['id']})"
+        assert str(device_w_name) == "im a real boy"

--- a/tests/integration/test_dcim.py
+++ b/tests/integration/test_dcim.py
@@ -141,5 +141,5 @@ class TestSimpleServerRackingAndConnecting:
             site=site.id,
             status="active",
         )
-        assert str(device_no_name) == f"Arista dcs-7050tx3-48c8 ({device_no_name['id']})"
+        assert str(device_no_name) == f"Arista DCS-7050TX3-48C8 ({device_no_name['id']})"
         assert str(device_w_name) == "im a real boy"


### PR DESCRIPTION
Fixes #34 

All objects from Nautobot have the display field and if not, it will make it a blank string.