### PR TITLE
Resolves #71 - updating to account for json type custom field

### DIFF
--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -59,10 +59,6 @@ def get_return(lookup, return_fields=None):
         return lookup
 
 
-def flatten_custom(custom_dict):
-    return {k: v if not isinstance(v, dict) else v["value"] for k, v in custom_dict.items()}
-
-
 class JsonField(object):
     """Explicit field type for values that are not to be converted
     to a Record object"""
@@ -335,10 +331,9 @@ class Record(object):
         ret = {}
         for i in dict(self):
             current_val = getattr(self, i) if not init else init_vals.get(i)
-            if i == "custom_fields":
-                ret[i] = flatten_custom(current_val)
-            elif i == "constraints":  # just pass constraints as it is (a JSON string)
+            if i in ["custom_fields", "constraints"]:  # just pass constraints as it is (a JSON string)
                 ret[i] = current_val
+
             else:
                 if isinstance(current_val, Record):
                     current_val = getattr(current_val, "serialize")(nested=True)

--- a/tests/fixtures/dcim/site.json
+++ b/tests/fixtures/dcim/site.json
@@ -14,9 +14,9 @@
     "comments": "",
     "custom_fields": {
         "test_custom": "Hello",
-        "test_selection": {
-            "value": 2,
-            "label": "second"
+        "test_json": {
+            "first_key": 2,
+            "second_key": "second"
         }
     },
     "count_prefixes": 2,

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -111,12 +111,12 @@ class SiteTestCase(Generic.Tests):
         self.assertEqual(ret.custom_fields["test_custom"], "Testing")
 
     @patch("requests.sessions.Session.get", return_value=Response(fixture="dcim/site.json"))
-    def test_custom_selection_serializer(self, _):
+    def test_custom_field_json(self, _):
         """Tests serializer with custom selection fields."""
         ret = self.endpoint.get(self.uuid)
         ret.custom_fields["test_custom"] = "Testing"
         test = ret.serialize()
-        self.assertEqual(test["custom_fields"]["test_selection"], 2)
+        self.assertEqual(test["custom_fields"]["test_json"]["second_key"], "second")
 
     @patch("requests.sessions.Session.post", return_value=Response(fixture="dcim/site.json"))
     def test_create(self, mock):


### PR DESCRIPTION
I need someone with prior knowledge on this SDK to confirm we no longer need this function. as my local testing with nautobot v1.4.1 I cannot get that function to be triggered.