### PR TITLE
v1.2.1 Add Feature: Removing the restriction on id for filter #76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
-## v1.2.0
+## v1.2.1
+
+- (#76) Feature: Removing the restriction on `id` for filter
+
+    It is now allowed to filter per id. (switch = devices.get(id="..."))
+
+e## v1.2.0
 
 ### Significant Updates
 
 - (#71) Drops support for Python3.6 and updates package dependencies.
+
 ### Bug Fixes
 
 - (#75) Fixes child prefixes for the **available-prefixes/ips** endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
     It is now allowed to filter per id. (switch = devices.get(id="..."))
 
-e## v1.2.0
+## v1.2.0
 
 ### Significant Updates
 

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -18,7 +18,7 @@ This file has been modified by NetworktoCode, LLC.
 from pynautobot.core.query import Request, RequestError
 from pynautobot.core.response import Record
 
-RESERVED_KWARGS = ("id", "pk", "limit", "offset")
+RESERVED_KWARGS = ("pk", "limit", "offset")
 
 
 def response_loader(req, return_obj, endpoint):

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -22,6 +22,18 @@ class DeviceTestCase(Generic.Tests):
         self.assertIsInstance(ret.local_context_data, dict)
         mock.assert_called_with(self.detail_uri, params={}, json=None, headers=HEADERS)
 
+    @patch("requests.sessions.Session.get", return_value=Response(fixture="dcim/device.json"))
+    def test_get_by_id(self, mock):
+        params = {"id": self.uuid}
+        ret = self.endpoint.filter(**params)
+        self.assertIsInstance(ret, self.ret)
+        self.assertIsInstance(ret.primary_ip, pynautobot.core.response.Record)
+        self.assertIsInstance(ret.primary_ip4, pynautobot.core.response.Record)
+        self.assertIsInstance(ret.config_context, dict)
+        self.assertIsInstance(ret.custom_fields, dict)
+        self.assertIsInstance(ret.local_context_data, dict)
+        mock.assert_called_with(self.bulk_uri, params=params, json=None, headers=HEADERS)
+
     @patch("requests.sessions.Session.get", return_value=Response(fixture="dcim/devices.json"))
     def test_multi_filter(self, mock):
         params = {"role": ["test", "test1"], "site": "TEST#1"}

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -28,7 +28,11 @@ class EndPointTestCase(unittest.TestCase):
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as _:
-            test_obj.filter(id=1)
+            test_obj.filter(pk=1)
+        with self.assertRaises(ValueError) as _:
+            test_obj.filter(limit=1)
+        with self.assertRaises(ValueError) as _:
+            test_obj.filter(offset=1)
 
     def test_choices(self):
         with patch("pynautobot.core.query.Request.options", return_value=Mock()) as mock:


### PR DESCRIPTION
Implement: #76 

It is now allowed to filter per `id`. (switch = devices.get(id="..."))