### PR TITLE
docs: fix travis badge dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![pynautobot](docs/nautobot_logo.svg "Nautobot logo")
 
-# Pynautobot [![build main](https://app.travis-ci.com/nautobot/pynautobot.svg?branch=main)](https://app.travis-ci.com/nautobot/pynautobot)
+# Pynautobot
 Python API client library for [Nautobot](https://github.com/nautobot/nautobot).
 
 > Pynautobot was initially developed as a fork of [pynetbox](https://github.com/digitalocean/pynetbox/).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![pynautobot](docs/nautobot_logo.svg "Nautobot logo")
 
-# Pynautobot [![build main](https://travis-ci.com/nautobot/pynautobot.svg?branch=main)](https://travis-ci.com/nautobot/pynautobot)
+# Pynautobot [![build main](https://app.travis-ci.com/nautobot/pynautobot.svg?branch=main)](https://app.travis-ci.com/nautobot/pynautobot)
 Python API client library for [Nautobot](https://github.com/nautobot/nautobot).
 
 > Pynautobot was initially developed as a fork of [pynetbox](https://github.com/digitalocean/pynetbox/).


### PR DESCRIPTION
The link under the Travis badge in [README.md](https://github.com/nautobot/pynautobot/blob/a939834bacddeacacf749ad8bfddf0b4ca678856/README.md) was broken. This PR fixes it.