### PR TITLE
Fixes plugin nested endpoints

### DIFF
--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -279,7 +279,7 @@ class Record(object):
         if split_url_path[2] == "plugins":
             # Keep plugins in app path
             app = "/".join(split_url_path[2:4])
-            name = split_url_path[4]
+            name = "/".join(split_url_path[4:-2])
         else:
             app, name = split_url_path[2:4]
         return getattr(pynautobot.core.app.App(self.api, app), name)

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -299,6 +299,21 @@ class RecordTestCase(unittest.TestCase):
         ret = test._endpoint_from_url(test.url)
         self.assertEqual(ret.name, "test-endpoint")
 
+    def test_endpoint_from_url_with_plugin_nested_endpoints(self):
+        api = Mock()
+        api.base_url = "http://localhost:8080/testing/api"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "url": "http://localhost:8080/testing/api/plugins/test-app/test-endpoint/test-nested-endpoint/1/",
+            },
+            api,
+            None,
+        )
+        ret = test._endpoint_from_url(test.url)
+        self.assertEqual(ret.name, "test-endpoint/test-nested-endpoint")
+
     def test_serialize_tag_list_order(self):
         """Add tests to ensure we're preserving tag order
 


### PR DESCRIPTION
This fixes when a plugin has nested endpoints. For example:
```
https://example.com/api/plugins/app_name/endpoint_name/nested_endpoint_name/<uuid>/
```

Resolves: #83 