### PR TITLE
Add a `retries` option to allow more resilient operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ![pynautobot](docs/nautobot_logo.svg "Nautobot logo")
 
 # Pynautobot
+
 Python API client library for [Nautobot](https://github.com/nautobot/nautobot).
 
 > Pynautobot was initially developed as a fork of [pynetbox](https://github.com/digitalocean/pynetbox/).
-  Pynetbox was originally developed by Zach Moody at DigitalOcean and the NetBox Community.
-
+> Pynetbox was originally developed by Zach Moody at DigitalOcean and the NetBox Community.
 
 The complete documentation for pynautobot can be found at [Read the Docs](https://pynautobot.readthedocs.io/en/stable/).
 
@@ -34,7 +34,6 @@ Virtual environment already activated: /home/user/pynautobot/.venv
 $ poetry install
 ...
 ```
-
 
 ## Quick Start
 
@@ -86,7 +85,7 @@ hq
 
 ### Threading
 
-Pynautobot supports multithreaded calls for `.filter()` and `.all()` queries. It is **highly recommended** you have `MAX_PAGE_SIZE` in your Nautobot install set to anything *except* `0` or `None`. The default value of `1000` is usually a good value to use. To enable threading, add `threading=True` parameter when instantiating the `Api` object:
+Pynautobot supports multithreaded calls for `.filter()` and `.all()` queries. It is **highly recommended** you have `MAX_PAGE_SIZE` in your Nautobot install set to anything _except_ `0` or `None`. The default value of `1000` is usually a good value to use. To enable threading, add `threading=True` parameter when instantiating the `Api` object:
 
 ```python
 nautobot = pynautobot.api(
@@ -100,7 +99,8 @@ nautobot = pynautobot.api(
 
 Used for Nautobot Rest API versioning. Versioning can be controlled globally by setting `api_version` on initialization of the `API` class and/or for a specific request e.g (`list()`, `get()`, `create()` etc.) by setting an optional `api_version` parameter.
 
-__Global versioning__
+**Global versioning**
+
 ```python
 import pynautobot
 nautobot = pynautobot.api(
@@ -110,7 +110,8 @@ nautobot = pynautobot.api(
 )
 ```
 
-__Request specific versioning__
+**Request specific versioning**
+
 ```python
 import pynautobot
 nautobot = pynautobot.api(
@@ -119,6 +120,21 @@ nautobot = pynautobot.api(
 tags = nautobot.extras.tags
 tags.create(name="Tag", slug="tag", api_version="1.2",)
 tags.list(api_version="1.3",)
+```
+
+### Retry logic
+
+By default, the client will not retry any operation. This behavior can be adjusted via the `retries` optional parameters. This will only affect for HTTP codes: 429, 501, 502, 503 and 504.
+
+**Retries**
+
+```python
+import pynautobot
+nautobot = pynautobot.api(
+    url="http://localhost:8000",
+    token="d6f4e314a5b5fefd164995169f28ae32d987704f",
+    retries=3
+)
 ```
 
 ## Related projects

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ tags.list(api_version="1.3",)
 
 ### Retry logic
 
-By default, the client will not retry any operation. This behavior can be adjusted via the `retries` optional parameters. This will only affect for HTTP codes: 429, 501, 502, 503 and 504.
+By default, the client will not retry any operation. This behavior can be adjusted via the `retries` optional parameters. This will only affect for HTTP codes: 429, 500, 502, 503 and 504.
 
 **Retries**
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,8 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import ANY, Mock, patch, call
+from http.client import HTTPMessage
 
+from pynautobot.core.query import RequestErrorFromException
 import pynautobot
 
 host = "http://localhost:8000"
@@ -85,3 +87,46 @@ class ApiStatusTestCase(unittest.TestCase):
             host,
         )
         self.assertEqual(api.status()["nautobot-version"], "1.3.2")
+
+
+class ApiRetryTestCase(unittest.TestCase):
+    class ResponseWithStatus:
+        ok = False
+        status_code = 429
+
+    @patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
+    def test_api_retry(self, getconn_mock):
+        getconn_mock.return_value.getresponse.side_effect = [
+            Mock(status=500, msg=HTTPMessage()),
+            Mock(status=429, msg=HTTPMessage()),
+            Mock(status=200, msg=HTTPMessage()),
+        ]
+
+        api = pynautobot.api(
+            "http://any.url/",
+            retries=1,
+        )
+
+        api.version
+
+        assert getconn_mock.return_value.request.mock_calls == [
+            call("GET", "/api/", body=None, headers=ANY),
+            call("GET", "/api/", body=None, headers=ANY),
+            call("GET", "/api/", body=None, headers=ANY),
+        ]
+
+    @patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
+    def test_api_retry_fails(self, getconn_mock):
+        getconn_mock.return_value.getresponse.side_effect = [
+            Mock(status=500, msg=HTTPMessage()),
+            Mock(status=429, msg=HTTPMessage()),
+            Mock(status=200, msg=HTTPMessage()),
+        ]
+
+        api = pynautobot.api(
+            "http://any.url/",
+            retries=1,
+        )
+
+        with self.assertRaises(RequestErrorFromException):
+            api.version

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -104,7 +104,7 @@ class ApiRetryTestCase(unittest.TestCase):
 
         api = pynautobot.api(
             "http://any.url/",
-            retries=1,
+            retries=2,
         )
 
         api.version


### PR DESCRIPTION
This PR proposes to add a **retry** logic to the SDK, so it will be more "persistent" in front of temporal issues on the server.
This should help to mitigate issue [#16](https://github.com/nautobot/nautobot-ansible/issues/169)

If the idea is welcomed, I would complete the PR adding proper testing.
