### PR TITLE
Release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.2
+
+### Bug Fixes
+
+- (#84) Fixes URLs for plugins with nested endpoints (i.e. /api/plugins/app_name/endpoint/nested_endpoint)
+
 ## v1.2.1
 
 - (#76) Feature: Removing the restriction on `id` for filter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [tool.poetry]
 name = "pynautobot"
-version = "1.2.1"
+version = "1.2.2"
 description = "Nautobot API client library"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"


### PR DESCRIPTION
### Bug Fixes

- (#84) Fixes URLs for plugins with nested endpoints (i.e. /api/plugins/app_name/endpoint/nested_endpoint)