### PR TITLE
Handle app names including dash -

### DIFF
--- a/pynautobot/core/app.py
+++ b/pynautobot/core/app.py
@@ -141,7 +141,7 @@ class PluginsApp(object):
         self.api = api
 
     def __getattr__(self, name):
-        return App(self.api, "plugins/{}".format(name))
+        return App(self.api, f"plugins/{name.replace('_', '-')}")
 
     def installed_plugins(self):
         """Returns raw response with installed plugins

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -50,14 +50,13 @@ class Endpoint(object):
 
     def __init__(self, api, app, name, model=None):
         self.return_obj = self._lookup_ret_obj(name, model)
-        self.app_name = app.name.replace("_", "-")
         self.name = name.replace("_", "-")
         self.api = api
         self.base_url = api.base_url
         self.token = api.token
         self.url = "{base_url}/{app}/{endpoint}".format(
             base_url=self.base_url,
-            app=self.app_name,
+            app=app.name,
             endpoint=self.name,
         )
         self._choices = None

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -50,13 +50,14 @@ class Endpoint(object):
 
     def __init__(self, api, app, name, model=None):
         self.return_obj = self._lookup_ret_obj(name, model)
+        self.app_name = app.name.replace("_", "-")
         self.name = name.replace("_", "-")
         self.api = api
         self.base_url = api.base_url
         self.token = api.token
         self.url = "{base_url}/{app}/{endpoint}".format(
             base_url=self.base_url,
-            app=app.name,
+            app=self.app_name,
             endpoint=self.name,
         )
         self._choices = None


### PR DESCRIPTION
Currently access app names including a - character results in an error, as underscores are not converted to dashes i.e.:

```
In [2]: nb.plugins.golden_config.config_compliance.all()
...
RequestError: The requested url: https://nautobot-staging.internal/api/plugins/golden_config/config-compliance/?limit=0 could not be found.
```


