### PR TITLE
Fixes version parsing in unit test

### DIFF
--- a/tests/integration/test_api_version.py
+++ b/tests/integration/test_api_version.py
@@ -1,3 +1,5 @@
+from packaging import version
+
 import pytest
 import pynautobot
 
@@ -20,7 +22,7 @@ class TestAPIVersioning:
         status = nb_client.status()
         assert status
         assert status.get("nautobot-version")
-        if status["nautobot-version"] < "1.3":
+        if version.parse(status["nautobot-version"]) < version.parse("1.3"):
             pytest.skip("API versioning is only in Nautobot 1.3+")
 
         return status["nautobot-version"]


### PR DESCRIPTION
When I built this test I hastily only compared simple version strings (1.2.99, 1.3.1, 1.4, etc), but once the minor version grows to double digits (1.10.0) the original method will break.