### PR TITLE
Upstream testing feasibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,13 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
-      - name: "Set up Python"
-        uses: "actions/setup-python@v2"
-        with:
-          python-version: "3.9"
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v4"
+      - name: "Set up Docker Buildx"
+        id: "buildx"
+        uses: "docker/setup-buildx-action@v1"
+      - name: "Install Python Packages"
+        run: "pip install poetry"
       - name: "Tests"
         run: "poetry run invoke tests"
   publish_pypi:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
       - name: "Set up Docker Buildx"
         id: "buildx"
         uses: "docker/setup-buildx-action@v1"
-      - name: "Install Python Packages"
-        run: "pip install poetry"
       - name: "Tests"
         run: "poetry run invoke tests"
   publish_pypi:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
-      - name: "Install CICD dependencies"
-        run: "pip install -U pip && pip install poetry"
-      - name: "Tests"
-        run: "poetry run invoke tests"
+      - name: "Set up Python"
+        uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
   publish_pypi:
     name: "Push Package to PyPI"
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,11 @@ jobs:
     env:
       PYTHON_VER: "${{ matrix.python-version }}"
       NAUTOBOT_VER: "${{ matrix.nautobot-version }}"
-      INVOKE_LOCAL: true
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
       - name: "Install CICD dependencies"
         run: "pip install -U pip && pip install poetry"
-      - name: "Install project dependencies via Poetry"
-        run: "poetry install"
-      - name: "Start containers"
-        run: "poetry run invoke start"
-      - name: "Wait for Nautobot to become available."
-        run: "poetry run invoke wait"
       - name: "Tests"
         run: "poetry run invoke tests"
   publish_pypi:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        nautobot-version: ["1.2", "1.3"]
+        nautobot-version: ["1.2", "1.3", "stable"]
         exclude:
           - python-version: 3.10
             nautobot-version: 1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
+      - name: "Tests"
+        run: "poetry run invoke tests"
   publish_pypi:
     name: "Push Package to PyPI"
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/upstream_testing.yml
+++ b/.github/workflows/upstream_testing.yml
@@ -4,7 +4,6 @@ name: "Nautobot Upstream Monitor"
 on:  # yamllint disable-line rule:truthy rule:comments
   schedule:
     - cron: "0 4 */2 * *"  # every other day at midnight
-  push: {}
 
 jobs:
   upstream-test:

--- a/.github/workflows/upstream_testing.yml
+++ b/.github/workflows/upstream_testing.yml
@@ -12,4 +12,3 @@ jobs:
     with:  # Below could potentially be collapsed into a single argument if a concrete relationship between both is enforced
       invoke_context_name: "PYNAUTOBOT"
       plugin_name: "pynautobot"
-

--- a/.github/workflows/upstream_testing.yml
+++ b/.github/workflows/upstream_testing.yml
@@ -1,0 +1,15 @@
+---
+name: "Nautobot Upstream Monitor"
+
+on:  # yamllint disable-line rule:truthy rule:comments
+  schedule:
+    - cron: "0 4 */2 * *"  # every other day at midnight
+  push: {}
+
+jobs:
+  upstream-test:
+    uses: "nautobot/nautobot/.github/workflows/plugin_upstream_testing_base.yml@develop"
+    with:  # Below could potentially be collapsed into a single argument if a concrete relationship between both is enforced
+      invoke_context_name: "PYNAUTOBOT"
+      plugin_name: "pynautobot"
+

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -5,8 +5,8 @@ FROM python:${PYTHON_VER}-slim
 RUN pip install --upgrade pip \
   && pip install poetry
 
-WORKDIR /local
-COPY pyproject.toml /local
+WORKDIR /source
+COPY pyproject.toml /source
 
 RUN poetry config virtualenvs.create false \
   && poetry install --no-interaction --no-ansi

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -y update && apt-get -y install --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sSL https://install.python-poetry.org | python3 - && \
-  /root/.local/bin/poetry config virtualenvs.create false
+    /root/.local/bin/poetry config virtualenvs.create false
 
 WORKDIR /source
 COPY pyproject.toml /source

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -2,11 +2,17 @@ ARG PYTHON_VER
 
 FROM python:${PYTHON_VER}-slim
 
-RUN pip install --upgrade pip \
-  && pip install poetry
+RUN apt-get -y update && apt-get -y install --no-install-recommends \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://install.python-poetry.org | python3 - && \
+  /root/.local/bin/poetry config virtualenvs.create false
 
 WORKDIR /source
 COPY pyproject.toml /source
 
-RUN poetry config virtualenvs.create false \
-  && poetry install --no-interaction --no-ansi
+RUN git config --global --add safe.directory /source
+
+RUN /root/.local/bin/poetry install --no-interaction --no-ansi

--- a/development/Dockerfile.dockerignore
+++ b/development/Dockerfile.dockerignore
@@ -1,0 +1,3 @@
+**/*
+
+!/pyproject.toml

--- a/development/creds.example.env
+++ b/development/creds.example.env
@@ -1,0 +1,2 @@
+# Empty file to mimic plugins that requires a creds file for upstream testing
+# [see](https://github.com/nautobot/nautobot/blob/develop/.github/workflows/plugin_upstream_testing_base.yml#L47)

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,6 +1,15 @@
 ---
 version: "3"
 services:
+  pynautobot-dev:
+    image: "$IMAGE_NAME:$IMAGE_VER"
+    build:
+      context: $PWD
+      dockerfile: development/Dockerfile
+      args:
+        PYTHON_VER:
+    volumes:
+      - $PWD:/source
   nautobot:
     image: "ghcr.io/nautobot/nautobot-dev:${NAUTOBOT_VER:-1.3}-py${PYTHON_VER:-3.7}"
     command: "nautobot-server runserver 0.0.0.0:8000 --insecure"

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -10,6 +10,9 @@ services:
         PYTHON_VER:
     volumes:
       - $PWD:/source
+    depends_on:
+      nautobot:
+        condition: "service_healthy"
   nautobot:
     image: "ghcr.io/nautobot/nautobot-dev:${NAUTOBOT_VER:-1.3}-py${PYTHON_VER:-3.7}"
     command: "nautobot-server runserver 0.0.0.0:8000 --insecure"
@@ -21,6 +24,14 @@ services:
     env_file:
       - "./dev.env"
     tty: true
+    healthcheck:
+      interval: "30s"
+      timeout: "10s"
+      start_period: "30s"
+      retries: 4
+      test:
+        - CMD-SHELL
+        - curl --fail http://localhost:8000/health/ || exit 1
   postgres:
     image: "postgres:13"
     env_file:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -3,17 +3,17 @@ version: "3"
 
 x-common: &common
   image: "${IMAGE_NAME}:${IMAGE_VER}"
-  build:
-    context: "${PWD}"
-    dockerfile: "development/Dockerfile"
-    args:
-      PYTHON_VER: "${PYTHON_VER}"
   volumes:
     - "${PWD}:/source"
 
 services:
   pynautobot-dev:
     <<: *common
+    build:
+      context: "${PWD}"
+      dockerfile: "development/Dockerfile"
+      args:
+        PYTHON_VER: "${PYTHON_VER}"
   pynautobot-dev-tests:
     <<: *common
     depends_on:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,15 +1,21 @@
 ---
 version: "3"
+
+x-common: &common
+  image: "${IMAGE_NAME}:${IMAGE_VER}"
+  build:
+    context: "${PWD}"
+    dockerfile: "development/Dockerfile"
+    args:
+      PYTHON_VER: "${PYTHON_VER}"
+  volumes:
+    - "${PWD}:/source"
+
 services:
   pynautobot-dev:
-    image: "$IMAGE_NAME:$IMAGE_VER"
-    build:
-      context: $PWD
-      dockerfile: development/Dockerfile
-      args:
-        PYTHON_VER:
-    volumes:
-      - $PWD:/source
+    <<: *common
+  pynautobot-dev-tests:
+    <<: *common
     depends_on:
       nautobot:
         condition: "service_healthy"
@@ -27,11 +33,11 @@ services:
     healthcheck:
       interval: "30s"
       timeout: "10s"
-      start_period: "30s"
+      start_period: "2m"
       retries: 4
       test:
-        - CMD-SHELL
-        - curl --fail http://localhost:8000/health/ || exit 1
+        - "CMD-SHELL"
+        - "curl --fail http://localhost:8000/health/ || exit 1"
   postgres:
     image: "postgres:13"
     env_file:

--- a/pynautobot/models/dcim.py
+++ b/pynautobot/models/dcim.py
@@ -38,7 +38,7 @@ class TraceableRecord(Record):
             "dcim/rear-ports": RearPorts,
         }
         ret = []
-        for (termination_a_data, cable_data, termination_b_data) in req.get():
+        for termination_a_data, cable_data, termination_b_data in req.get():
             this_hop_ret = []
             for hop_item_data in (termination_a_data, cable_data, termination_b_data):
                 # if not fully terminated then some items will be None

--- a/pynautobot/models/virtualization.py
+++ b/pynautobot/models/virtualization.py
@@ -19,5 +19,4 @@ from pynautobot.core.response import Record, JsonField
 
 
 class VirtualMachines(Record):
-
     config_context = JsonField

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ requests = "^2.20.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"
-pytest-docker = "*"
 requests_mock = "*"
 pyyaml = "*"
 pylint = "*"

--- a/tasks.py
+++ b/tasks.py
@@ -146,7 +146,7 @@ def pytest(context, local=INVOKE_LOCAL, label="", failfast=False, keepdb=False):
     # Install python module
 
     if keepdb:
-        raise NotImplementedError("--keepdb is not implemented yet")
+        print("WARNING: --keepdb is not implemented yet")
 
     command = [
         "" if local else "docker-compose run --rm -- pynautobot-dev",

--- a/tasks.py
+++ b/tasks.py
@@ -47,6 +47,8 @@ _DOCKER_COMPOSE_ENV = {
     "COMPOSE_PROJECT_NAME": "pynautobot",
     "IMAGE_NAME": IMAGE_NAME,
     "IMAGE_VER": IMAGE_VER,
+    "PYTHON_VER": PYTHON_VER,
+    "NAUTOBOT_VER": getenv("NAUTOBOT_VER", "stable"),
 }
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -134,7 +134,7 @@ def rebuild(context):
 
 
 @task(aliases=("unittest",))
-def pytest(context, local=INVOKE_LOCAL, label=""):
+def pytest(context, local=INVOKE_LOCAL, label="", failfast=False, keepdb=False):
     """Run pytest for the specified name and Python version.
 
     Args:
@@ -144,9 +144,14 @@ def pytest(context, local=INVOKE_LOCAL, label=""):
     # pty is set to true to properly run the docker commands due to the invocation process of docker
     # https://docs.pyinvoke.org/en/latest/api/runners.html - Search for pty for more information
     # Install python module
+
+    if keepdb:
+        raise NotImplementedError("--keepdb is not implemented yet")
+
     command = [
         "" if local else "docker-compose run --rm -- pynautobot-dev",
         "pytest -vv",
+        "--maxfail=1" if failfast else "",
         label,
     ]
     context.run(" ".join(command), env=_DOCKER_COMPOSE_ENV, pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -16,12 +16,23 @@ TOOL_CONFIG = PYPROJECT_CONFIG["tool"]["poetry"]
 NAUTOBOT_VER = os.getenv("INVOKE_PYNAUTOBOT_NAUTOBOT_VER", os.getenv("NAUTOBOT_VER", "stable"))
 # Can be set to a separate Python version to be used for launching or building image
 PYTHON_VER = os.getenv("INVOKE_PYNAUTOBOT_PYTHON_VER", os.getenv("PYTHON_VER", "3.8"))
-# Name of the docker image/image
-IMAGE_NAME = os.getenv("IMAGE_NAME")
-if IMAGE_NAME is None:
-    IMAGE_NAME = TOOL_CONFIG["name"]
-# Tag for the image
-IMAGE_VER = os.getenv("IMAGE_VER", f"{TOOL_CONFIG['version']}-py{PYTHON_VER}")
+
+
+def _get_image_name_and_tag():
+    """Return image name and tag. Necessary to avoid double build in upstream testing"""
+
+    workflow_name = os.getenv("GITHUB_WORKFLOW")
+    if workflow_name == "Nautobot Plugin Upstream Testing - Base":
+        return "pynautobot/nautobot", f"{NAUTOBOT_VER}-py{PYTHON_VER}"
+
+    image_name = os.getenv("IMAGE_NAME", TOOL_CONFIG["name"])
+    image_tag = os.getenv("IMAGE_VER", f"{TOOL_CONFIG['version']}-py{PYTHON_VER}")
+
+    return image_name, image_tag
+
+
+IMAGE_NAME, IMAGE_VER = _get_image_name_and_tag()
+
 # Gather current working directory for Docker commands
 PWD = os.getcwd()
 # Local or Docker execution provide "local" to run locally without docker execution

--- a/tasks.py
+++ b/tasks.py
@@ -80,6 +80,25 @@ def down(context, remove=False):
     return context.run(" ".join(command), env=_DOCKER_COMPOSE_ENV, pty=True)
 
 
+@task(
+    help={
+        "service": "Docker-compose service name to view (default: nautobot)",
+        "follow": "Follow logs",
+        "tail": "Tail N number of lines or 'all'",
+    }
+)
+def logs(context, service="", follow=False, tail=None):
+    """View the logs of a docker-compose service."""
+    command = [
+        "docker-compose logs",
+        "--follow" if follow else "",
+        f"--tail={tail}" if tail else "",
+        service if service else "",
+    ]
+
+    context.run(" ".join(command), env=_DOCKER_COMPOSE_ENV, pty=True)
+
+
 @task
 def debug(context):
     print("Starting Nautobot in debug mode...")

--- a/tasks.py
+++ b/tasks.py
@@ -134,7 +134,7 @@ def rebuild(context):
 
 
 @task(aliases=("unittest",))
-def pytest(context, local=INVOKE_LOCAL):
+def pytest(context, local=INVOKE_LOCAL, label=""):
     """Run pytest for the specified name and Python version.
 
     Args:
@@ -147,6 +147,7 @@ def pytest(context, local=INVOKE_LOCAL):
     command = [
         "" if local else "docker-compose run --rm -- pynautobot-dev",
         "pytest -vv",
+        label,
     ]
     context.run(" ".join(command), env=_DOCKER_COMPOSE_ENV, pty=True)
 
@@ -242,8 +243,8 @@ def cli(context):
     Args:
         context (obj): Used to run specific commands
     """
-    dev = f"docker run -it -v {PWD}:/local {IMAGE_NAME}:{IMAGE_VER} /bin/bash"
-    context.run(f"{dev}", pty=True)
+    # dev = f"docker run -it -v {PWD}:/local {IMAGE_NAME}:{IMAGE_VER} /bin/bash"
+    context.run("docker-compose run --rm -- pynautobot-dev bash", env=_DOCKER_COMPOSE_ENV, pty=True)
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -28,8 +28,9 @@ def is_truthy(arg):
 PYPROJECT_CONFIG = toml.load("pyproject.toml")
 TOOL_CONFIG = PYPROJECT_CONFIG["tool"]["poetry"]
 
+NAUTOBOT_VER = os.getenv("INVOKE_PYNAUTOBOT_NAUTOBOT_VER", os.getenv("NAUTOBOT_VER", "stable"))
 # Can be set to a separate Python version to be used for launching or building image
-PYTHON_VER = os.getenv("PYTHON_VER", "3.7")
+PYTHON_VER = os.getenv("INVOKE_PYNAUTOBOT_PYTHON_VER", os.getenv("PYTHON_VER", "3.8"))
 # Name of the docker image/image
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 if IMAGE_NAME is None:
@@ -47,8 +48,8 @@ _DOCKER_COMPOSE_ENV = {
     "COMPOSE_PROJECT_NAME": "pynautobot",
     "IMAGE_NAME": IMAGE_NAME,
     "IMAGE_VER": IMAGE_VER,
+    "NAUTOBOT_VER": NAUTOBOT_VER,
     "PYTHON_VER": PYTHON_VER,
-    "NAUTOBOT_VER": os.getenv("NAUTOBOT_VER", "stable"),
 }
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -21,8 +21,8 @@ PYTHON_VER = os.getenv("INVOKE_PYNAUTOBOT_PYTHON_VER", os.getenv("PYTHON_VER", "
 def _get_image_name_and_tag():
     """Return image name and tag. Necessary to avoid double build in upstream testing"""
 
-    workflow_name = os.getenv("GITHUB_WORKFLOW")
-    if workflow_name == "Nautobot Plugin Upstream Testing - Base":
+    workflow_name = os.getenv("GITHUB_WORKFLOW", "")
+    if "upstream" in workflow_name.lower():
         return "pynautobot/nautobot", f"{NAUTOBOT_VER}-py{PYTHON_VER}"
 
     image_name = os.getenv("IMAGE_NAME", TOOL_CONFIG["name"])

--- a/tasks.py
+++ b/tasks.py
@@ -48,7 +48,7 @@ _DOCKER_COMPOSE_ENV = {
     "IMAGE_NAME": IMAGE_NAME,
     "IMAGE_VER": IMAGE_VER,
     "PYTHON_VER": PYTHON_VER,
-    "NAUTOBOT_VER": getenv("NAUTOBOT_VER", "stable"),
+    "NAUTOBOT_VER": os.getenv("NAUTOBOT_VER", "stable"),
 }
 
 @task

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -146,10 +146,10 @@ def populate_nautobot_object_types(nb_api, devicetype_library_repo_dirpath):
 
 
 @pytest.fixture(scope="session")
-def nb_client(docker_ip, devicetype_library_repo_dirpath):
+def nb_client(devicetype_library_repo_dirpath):
     """Setup the nb_client and import necessary data."""
 
-    url = "http://{}:{}".format(docker_ip, 8000)
+    url = "http://{}:{}".format("nautobot", 8000)
     nb_api = pynautobot.api(url, token="0123456789abcdef0123456789abcdef01234567")
     populate_nautobot_object_types(nb_api=nb_api, devicetype_library_repo_dirpath=devicetype_library_repo_dirpath)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,6 +32,9 @@ DEVICE_ROLE_NAMES = [
     "Spine Switch",
 ]
 
+# When running tests locally `export NAUTOBOT_URL="http://localhost:8000"` (or wherever Nautobot runs) to override the default
+_NAUTOBOT_URL = os.getenv("NAUTOBOT_URL", "http://nautobot:8000")
+
 
 @pytest.fixture(scope="session")
 def git_toplevel():
@@ -149,8 +152,7 @@ def populate_nautobot_object_types(nb_api, devicetype_library_repo_dirpath):
 def nb_client(devicetype_library_repo_dirpath):
     """Setup the nb_client and import necessary data."""
 
-    url = "http://{}:{}".format("nautobot", 8000)
-    nb_api = pynautobot.api(url, token="0123456789abcdef0123456789abcdef01234567")
+    nb_api = pynautobot.api(_NAUTOBOT_URL, token="0123456789abcdef0123456789abcdef01234567")
     populate_nautobot_object_types(nb_api=nb_api, devicetype_library_repo_dirpath=devicetype_library_repo_dirpath)
 
     return nb_api

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -15,7 +15,6 @@ class EndPointTestCase(unittest.TestCase):
             self.assertEqual(len(test), 2)
 
     def test_filter_empty_kwargs(self):
-
         api = Mock(base_url="http://localhost:8000/api")
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")
@@ -23,7 +22,6 @@ class EndPointTestCase(unittest.TestCase):
             test_obj.filter()
 
     def test_filter_reserved_kwargs(self):
-
         api = Mock(base_url="http://localhost:8000/api")
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")


### PR DESCRIPTION
# Implements #108 

Enable upstream testing with Nautobot the same way as for plugins

## Done

- Added upstream testing workflow
- Changed invoke commands to use docker-compose
- Added invoke commands for better work with docker compose
- Fixed tests to use nautobot container
  - Can be configured with `NAUTOBOT_URL` environment variable
- Updated Docker configurations to be compatible with upstream testing
- Reformatted files with black
- Bumped default invoke `NAUTOBOT_VER=3.8`, as is in templates
- Updated CI to use docker-compose
- Added `stable` Nautobot version tests to CI