### PR TITLE
fix: Enhancement of __repr__ method (#67)

### DIFF
--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -206,7 +206,7 @@ class Record(object):
         return getattr(self, "display", None) or getattr(self, "name", None) or getattr(self, "label", None) or ""
 
     def __repr__(self):
-        return "<{}.{} name='{}' at {}>".format(self.__class__.__module__, self.__class__.__name__, self, hex(id(self)))
+        return "<{}.{} ('{}') at {}>".format(self.__class__.__module__, self.__class__.__name__, self, hex(id(self)))
 
     def __getstate__(self):
         return self.__dict__

--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -84,7 +84,7 @@ class Record(object):
 
     >>> x = nb.dcim.devices.get(1)
     >>> x
-    <pynautobot.models.dcim.Devices name='test1-switch1' at 0x1953d821250>
+    <pynautobot.models.dcim.Devices ('test1-switch1') at 0x1953d821250>
     >>>
 
     Querying a string field.

--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -80,11 +80,11 @@ class Record(object):
     :examples:
 
     Default representation of the object usually contains object's
-    class and object's name
+    class, object's name and it's location in memory
 
     >>> x = nb.dcim.devices.get(1)
     >>> x
-    <pynautobot.models.dcim.Devices object (name='test1-switch1')>
+    <pynautobot.models.dcim.Devices name='test1-switch1' at 0x1953d821250>
     >>>
 
     Querying a string field.
@@ -206,7 +206,7 @@ class Record(object):
         return getattr(self, "display", None) or getattr(self, "name", None) or getattr(self, "label", None) or ""
 
     def __repr__(self):
-        return "<{}.{} object (name='{}')>".format(self.__class__.__module__, self.__class__.__name__, self)
+        return "<{}.{} name='{}' at {}>".format(self.__class__.__module__, self.__class__.__name__, self, hex(id(self)))
 
     def __getstate__(self):
         return self.__dict__

--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -79,11 +79,12 @@ class Record(object):
 
     :examples:
 
-    Default representation of the object is usually its name
+    Default representation of the object usually contains object's
+    class and object's name
 
     >>> x = nb.dcim.devices.get(1)
     >>> x
-    test1-switch1
+    <pynautobot.models.dcim.Devices object (name='test1-switch1')>
     >>>
 
     Querying a string field.
@@ -205,7 +206,7 @@ class Record(object):
         return getattr(self, "display", None) or getattr(self, "name", None) or getattr(self, "label", None) or ""
 
     def __repr__(self):
-        return str(self)
+        return "<{}.{} object (name='{}')>".format(self.__class__.__module__, self.__class__.__name__, self)
 
     def __getstate__(self):
         return self.__dict__


### PR DESCRIPTION
Update `Record` class in pynautobot/core/response.py module. Add more detailed info the `__repr__()` method returns.

Example:

_main.py:_
```
def main():
    api_obj = api('http://localhost:8888',
                  token=os.environ.get('NAUTOBOT_API_TOKEN'))

    device = api_obj.dcim.devices.get('***')
    print(repr(device))

    print("=" * 79)

    interfaces_list = api_obj.dcim.interfaces.all()
    pprint(interfaces_list)

```

Output:
```
<pynautobot.models.dcim.Devices object (name='hAP lite router')>
===============================================================================
[<pynautobot.models.dcim.Interfaces object (name='test ethernet1/1 interface (ethernet1/1)')>,
 <pynautobot.models.dcim.Interfaces object (name='test ethernet1/2 interface (ethernet1/2)')>]
```