### PR TITLE
Add ipam namespace support

### DIFF
--- a/tests/fixtures/ipam/namespace.json
+++ b/tests/fixtures/ipam/namespace.json
@@ -1,0 +1,13 @@
+{
+  "id": "5b39ba88-e5ab-4be2-89f5-5a016473b53c",
+  "display": "internal",
+  "url": "http://localhost:8080/api/ipam/namespaces/5b39ba88-e5ab-4be2-89f5-5a016473b53c/",
+  "name": "internal",
+  "description": "",
+  "location": null,
+  "created": "2023-04-24T12:36:38.598529Z",
+  "last_updated": "2023-04-24T12:36:38.598564Z",
+  "tags": [],
+  "notes_url": "http://localhost:8080/api/ipam/namespaces/5b39ba88-e5ab-4be2-89f5-5a016473b53c/notes/",
+  "custom_fields": {}
+}

--- a/tests/fixtures/ipam/namespaces.json
+++ b/tests/fixtures/ipam/namespaces.json
@@ -1,0 +1,33 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": "c7671ec3-3900-4650-9dd7-ac538f2bee67",
+      "display": "Global",
+      "url": "http://localhost:8080/api/ipam/namespaces/c7671ec3-3900-4650-9dd7-ac538f2bee67/",
+      "name": "Global",
+      "description": "Default Global namespace. Created by Nautobot.",
+      "location": null,
+      "created": "2023-04-24T12:25:55.901435Z",
+      "last_updated": "2023-04-24T12:25:55.901447Z",
+      "tags": [],
+      "notes_url": "http://localhost:8080/api/ipam/namespaces/c7671ec3-3900-4650-9dd7-ac538f2bee67/notes/",
+      "custom_fields": {}
+    },
+    {
+      "id": "b0b85da2-4e5f-4b0f-a960-4f7bc5f225db",
+      "display": "internal",
+      "url": "http://localhost:8080/api/ipam/namespaces/b0b85da2-4e5f-4b0f-a960-4f7bc5f225db/",
+      "name": "internal",
+      "description": "",
+      "location": null,
+      "created": "2023-04-24T12:36:38.598529Z",
+      "last_updated": "2023-04-24T12:36:38.598564Z",
+      "tags": [],
+      "notes_url": "http://localhost:8080/api/ipam/namespaces/b0b85da2-4e5f-4b0f-a960-4f7bc5f225db/notes/",
+      "custom_fields": {}
+    }
+  ]
+}

--- a/tests/fixtures/ipam/prefix.json
+++ b/tests/fixtures/ipam/prefix.json
@@ -9,6 +9,14 @@
         "slug": "test1"
     },
     "vrf": null,
+    "namespace": {
+        "id": "5b39ba88-e5ab-4be2-89f5-5a016473b53c",
+        "display": "internal",
+        "url": "http://localhost:8080/api/ipam/namespaces/5b39ba88-e5ab-4be2-89f5-5a016473b53c/",
+        "name": "internal",
+        "description": "",
+        "location": null
+    },
     "tenant": null,
     "vlan": null,
     "status": {

--- a/tests/fixtures/ipam/vrf.json
+++ b/tests/fixtures/ipam/vrf.json
@@ -1,6 +1,14 @@
 {
     "id": "5b39ba88-e5ab-4be2-89f5-5a016473b53c",
     "name": "TEST",
+    "namespace": {
+        "id": "5b39ba88-e5ab-4be2-89f5-5a016473b53c",
+        "display": "internal",
+        "url": "http://localhost:8080/api/ipam/namespaces/5b39ba88-e5ab-4be2-89f5-5a016473b53c/",
+        "name": "internal",
+        "description": "",
+        "location": null
+    },
     "rd": "65535:1",
     "tenant": null,
     "enforce_unique": true,

--- a/tests/test_ipam.py
+++ b/tests/test_ipam.py
@@ -11,6 +11,22 @@ class PrefixTestCase(Generic.Tests):
     name = "prefixes"
     name_singular = "prefix"
 
+    @patch(
+        "requests.sessions.Session.get",
+        side_effect=[Response(fixture="ipam/namespace.json"), Response(fixture="ipam/prefix.json")],
+    )
+    def test_namespace_in_prefix(self, mock):
+        namespace = self.endpoint.get(self.uuid)
+        prefix = api.ipam.prefixes.get(self.uuid)
+        mock.assert_called_with(
+            f"http://localhost:8000/api/ipam/prefixes/{self.uuid}/",
+            params={},
+            json=None,
+            headers=HEADERS,
+        )
+        self.assertEqual(namespace.id, prefix.namespace.id)
+        self.assertEqual(namespace.name, prefix.namespace.name)
+
     @patch("requests.sessions.Session.get", return_value=Response(fixture="ipam/prefix.json"))
     def test_modify(self, *_):
         ret = self.endpoint.get(self.uuid)
@@ -153,6 +169,28 @@ class VlanGroupsTestCase(Generic.Tests):
 class VRFTestCase(Generic.Tests):
     app = "ipam"
     name = "vrfs"
+
+    @patch(
+        "requests.sessions.Session.get",
+        side_effect=[Response(fixture="ipam/namespace.json"), Response(fixture="ipam/vrf.json")],
+    )
+    def test_namespace_in_vrf(self, mock):
+        namespace = self.endpoint.get(self.uuid)
+        vrf = api.ipam.vrfs.get(self.uuid)
+        mock.assert_called_with(
+            f"http://localhost:8000/api/ipam/vrfs/{self.uuid}/",
+            params={},
+            json=None,
+            headers=HEADERS,
+        )
+        self.assertEqual(namespace.id, vrf.namespace.id)
+        self.assertEqual(namespace.name, vrf.namespace.name)
+
+
+class NameSpaceTestCase(Generic.Tests):
+    app = "ipam"
+    name = "namespaces"
+    name_singular = "namespace"
 
 
 # class ServicesTestCase(Generic.Tests):


### PR DESCRIPTION
Part of issue #117 
Depends on PR #116, which should be merged first.

Extends tests with namespace support.