### PR TITLE
Fix lack of poetry.lock in Dockerfile

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 - && \
     /root/.local/bin/poetry config virtualenvs.create false
 
 WORKDIR /source
-COPY pyproject.toml /source
+COPY pyproject.toml poetry.lock /source/
 
 RUN git config --global --add safe.directory /source
 

--- a/development/Dockerfile.dockerignore
+++ b/development/Dockerfile.dockerignore
@@ -1,3 +1,4 @@
 **/*
 
 !/pyproject.toml
+!/poetry.lock


### PR DESCRIPTION
`poetry.lock` was not added in `Dockerfile` making local poetry env and Docker env installing different packages versions. This is a fix.