### PR TITLE
Add Endpoint.update(id,data) method

### DIFF
--- a/docs/advanced/graphql.rst
+++ b/docs/advanced/graphql.rst
@@ -152,3 +152,12 @@ This example shows accessing data from the previous query.
     >>> # Get the name of the first site
     >>> graphql_response.json["data"]["sites"][0]["name"]
     'den'
+
+
+Saving Changes
+--------------
+
+The Nautobot GraphQL API is currently read-only. To make updates to objects, see:
+
+* :ref:`Updating objects without loading data`
+* :py:meth:`~pynautobot.core.endpoint.Endpoint.update`

--- a/docs/advanced/update.rst
+++ b/docs/advanced/update.rst
@@ -152,3 +152,43 @@ and fetching the object from Nautobot shows that ``face`` has also been left unc
     Front
     >>> tmp_hq_access_5.position
     42
+
+
+Updating objects without loading data
+-------------------------------------
+
+In some cases it may not be necessary to load an object to update it, for example
+if the ID and updated fields are known, the call HTTP PATCH may be made without
+performing an :py:meth:`~pynautobot.core.endpoint.Endpoint.get` first.
+
+In this case, the :py:meth:`~pynautobot.core.endpoint.Endpoint.update` method may
+be used to directly submit a PATCH to the Nautobot REST API. Using this reduces
+the number of API calls. It can be particularly useful as a way to update data
+fetched from the GraphQL API.
+
+The examples updates a Device record, however this can apply to other API
+:py:class:`~pynautobot.core.endpoint.Endpoint` types.
+
+.. code-block:: python
+
+    import os
+    from pynautobot import api
+
+    url = os.environ["NAUTOBOT_URL"]
+    token = os.environ["NAUTOBOT_TOKEN"]
+    nautobot = api(url=url, token=token)
+
+    # Update status and name fields
+    result = nautobot.dcim.devices.update(
+      id="491d799a-2b4d-41fc-80e1-7c5cbb5b71b6",
+      data={
+        "comments": "removed from service",
+        "status": "decommissioned",
+      },
+    )
+
+    print(result)  # will output True if successful
+
+References:
+
+* :ref:`Gathering Data from GraphQL Endpoint`

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -15,6 +15,7 @@ limitations under the License.
 
 This file has been modified by NetworktoCode, LLC.
 """
+from typing import Dict
 from pynautobot.core.query import Request, RequestError
 from pynautobot.core.response import Record
 
@@ -306,6 +307,43 @@ class Endpoint(object):
         ).post(args[0] if args else kwargs)
 
         return response_loader(req, self.return_obj, self)
+
+    def update(self, id: str, data: Dict[str, any]):
+        """
+        Update a resource with a dictionary.
+
+        Accepts the id of the object that needs to be updated as well as
+        a dictionary of k/v pairs used to update an object. The object
+        is directly updated on the server using a PATCH request without
+        fetching object information.
+
+        For fields requiring an object reference (such as a device location),
+        the API user is responsible for providing the object ID or the object
+        URL. This API will not accept the pynautobot object directly.
+
+        :arg str id: Identifier of the object being updated
+        :arg dict data: Dictionary containing the k/v to update the
+            record object with.
+        :returns: True if PATCH request was successful.
+        :example:
+
+        >>> nb.dcim.devices.update(id="0238a4e3-66f2-455a-831f-5f177215de0f", data={
+        ...     "name": "test-switch2",
+        ...     "serial": "ABC321",
+        ...     "location": "9b1f53c7-89fa-4fb2-a89a-b97364fef50c",
+        ... })
+        True
+        """
+        req = Request(
+            key=id,
+            base=self.url,
+            token=self.api.token,
+            http_session=self.api.http_session,
+            api_version=self.api.api_version,
+        )
+        if req.patch(data):
+            return True
+        return False
 
     def choices(self, api_version=None):
         """Returns all choices from the endpoint.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -91,6 +91,17 @@ class Generic:
                 mock.assert_called_with(self.detail_uri, params={}, json=None, headers=HEADERS)
                 delete.assert_called_with(self.detail_uri, params={}, json=None, headers=HEADERS)
 
+        def test_endpoint_update(self):
+            """Tests that calling Endpoint.update(id=x, data={...}) will result in an HTTP PATCH"""
+            with patch(
+                "requests.sessions.Session.patch",
+                return_value=Response(fixture=f"{self.app}/{self.name_singular}.json"),
+            ) as mock:
+                UPDATE_DATA = {"field1": "value1"}
+                ret = self.endpoint.update(id=self.uuid, data=UPDATE_DATA)
+                self.assertTrue(ret)
+                mock.assert_called_with(self.detail_uri, params={}, json=UPDATE_DATA, headers=HEADERS)
+
         def test_diff(self):
             with patch(
                 "requests.sessions.Session.get",


### PR DESCRIPTION
Adds an `Endpoint.update(id,data)` call to the endpoint API.

Closes #125