### PR TITLE
Fix (#141)

### DIFF
--- a/pynautobot/core/app.py
+++ b/pynautobot/core/app.py
@@ -86,38 +86,14 @@ class App(object):
 
         return self._choices
 
-    def custom_choices(self):
-        """Returns custom-fields response from app
-
-        .. note::
-
-            This method is deprecated and will be removed in pynautobot
-            2.0 or newer. Please use `custom_fields()` instead.
-
-        :Returns: Raw response from Nautobot's custom-fields endpoint.
-        :Raises: :py:class:`.RequestError` if called for an invalid endpoint.
-        :Example:
-
-        >>> nb.extras.custom_choices()
-        {'Testfield1': {'Testvalue2': 2, 'Testvalue1': 1},
-         'Testfield2': {'Othervalue2': 4, 'Othervalue1': 3}}
-        """
-        logger.warning(
-            "WARNING: The method 'custom_choices()' will be removed in "
-            "the next major version (2.x) of pynautobot. Please use "
-            "`custom_fields()` instead."
-        )
-
-        return self.custom_fields()
-
-    def custom_fields(self):
+    def get_custom_fields(self):
         """Returns custom-fields response from app
 
         :Returns: Raw response from Nautobot's custom-fields endpoint.
         :Raises: :py:class:`.RequestError` if called for an invalid endpoint.
         :Example:
 
-        >>> nb.extras.custom_fields()
+        >>> nb.extras.get_custom_fields()
         [
             {
                 "id": "5b39ba88-e5ab-4be2-89f5-5a016473b53c",
@@ -142,21 +118,20 @@ class App(object):
             },
         ]
         """
-        custom_fields = Request(
+        return Request(
             base=f"{self.api.base_url}/{self.name}/custom-fields/",
             token=self.api.token,
             http_session=self.api.http_session,
         ).get()
-        return custom_fields
 
-    def custom_field_choices(self):
+    def get_custom_field_choices(self):
         """Returns custom-field-choices response from app
 
         :Returns: Raw response from Nautobot's custom-field-choices endpoint.
         :Raises: :py:class:`.RequestError` if called for an invalid endpoint.
         :Example:
 
-        >>> nb.extras.custom_field_choices()
+        >>> nb.extras.get_custom_field_choices()
         [
             {
                 "id": "5b39ba88-e5ab-4be2-89f5-5a016473b53c",
@@ -175,12 +150,11 @@ class App(object):
             },
         ]
         """
-        custom_fields = Request(
+        return Request(
             base=f"{self.api.base_url}/{self.name}/custom-field-choices/",
             token=self.api.token,
             http_session=self.api.http_session,
         ).get()
-        return custom_fields
 
     def config(self):
         """Returns config response from app

--- a/tests/integration/test_extras.py
+++ b/tests/integration/test_extras.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+class TestCustomField:
+
+    """Verify we can create, custom field, and custom field choices."""
+
+    @pytest.fixture(scope="session")
+    def create_custom_field(self, nb_client):
+        data = {
+            "label": "test_cf",
+            "key": "test_cf",
+            "content_types": ["dcim.device"],
+            "type": "select",
+            "weight": 100,
+            "filter_logic": "loose",
+        }
+        return nb_client.extras.custom_fields.create(**data)
+
+    @pytest.fixture(scope="session")
+    def create_custom_field_choices(self, nb_client, create_custom_field):
+        data = {
+            "value": "A",
+            "custom_field": create_custom_field["id"],
+            "weight": 100,
+        }
+        return nb_client.extras.custom_field_choices.create(**data)
+
+    def test_custom_field(self, create_custom_field):
+        assert create_custom_field["label"] == "test_cf"
+
+    def test_custom_field_choice(self, create_custom_field_choices):
+        assert create_custom_field_choices["value"] == "A"
+
+    def test_custom_field_choice_to_cf(self, create_custom_field_choices, create_custom_field):
+        assert create_custom_field_choices["custom_field"]["id"] == create_custom_field["id"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,7 +20,7 @@ class AppCustomFieldsTestCase(unittest.TestCase):
     @patch("pynautobot.api.version", "2.0")
     def test_custom_fields(self, session_get_mock):
         api = pynautobot.api(host, **def_kwargs)
-        cfs = api.extras.custom_fields()
+        cfs = api.extras.get_custom_fields()
 
         session_get_mock.assert_called_once()
         expect_url = f"{api.base_url}/extras/custom-fields/"
@@ -46,7 +46,7 @@ class AppCustomFieldChoicesTestCase(unittest.TestCase):
     @patch("pynautobot.api.version", "2.0")
     def test_custom_field_choices(self, session_get_mock):
         api = pynautobot.api(host, **def_kwargs)
-        choices = api.extras.custom_field_choices()
+        choices = api.extras.get_custom_field_choices()
 
         session_get_mock.assert_called_once()
         expect_url = f"{api.base_url}/extras/custom-field-choices/"
@@ -85,11 +85,11 @@ class PluginAppCustomChoicesTestCase(unittest.TestCase):
         return_value={"Testfield1": {"TF1_1": 1, "TF1_2": 2}, "Testfield2": {"TF2_1": 3, "TF2_2": 4}},
     )
     @patch("pynautobot.api.version", "2.0")
-    def test_custom_choices(self, *_):
+    def test_custom_fields(self, *_):
         api = pynautobot.api(host, **def_kwargs)
-        choices = api.plugins.test_plugin.custom_fields()
-        self.assertEqual(len(choices), 2)
-        self.assertEqual(sorted(choices.keys()), ["Testfield1", "Testfield2"])
+        custom_fields = api.plugins.test_plugin.get_custom_fields()
+        self.assertEqual(len(custom_fields), 2)
+        self.assertEqual(sorted(custom_fields.keys()), ["Testfield1", "Testfield2"])
 
     @patch(
         "pynautobot.core.query.Request.get",


### PR DESCRIPTION
Add `get` to methods to fix `custom_fields` and `custom_field_choices` methods overlap with endpoints.
Fixes #141
