### PR TITLE
WiP: Add support for generic auth headers

### DIFF
--- a/pynautobot/core/api.py
+++ b/pynautobot/core/api.py
@@ -156,7 +156,10 @@ class Api(object):
         >>>
         """
         version = Request(
-            base=self.base_url, http_session=self.http_session, api_version=self.api_version
+            base=self.base_url,
+            http_session=self.http_session,
+            api_version=self.api_version,
+            auth_header=self.auth_header
         ).get_version()
         return version
 
@@ -181,6 +184,7 @@ class Api(object):
             base=self.base_url,
             http_session=self.http_session,
             api_version=self.api_version,
+            auth_header=self.auth_header
         ).get_openapi()
 
     def status(self):

--- a/pynautobot/core/app.py
+++ b/pynautobot/core/app.py
@@ -80,7 +80,7 @@ class App(object):
 
         self._choices = Request(
             base="{}/{}/_choices/".format(self.api.base_url, self.name),
-            token=self.api.token,
+            auth_header=self.api.auth_header,
             http_session=self.api.http_session,
         ).get()
 
@@ -144,7 +144,7 @@ class App(object):
         """
         return Request(
             base=f"{self.api.base_url}/{self.name}/custom-fields/",
-            token=self.api.token,
+            auth_header=self.api.auth_header,
             http_session=self.api.http_session,
         ).get()
 
@@ -176,7 +176,7 @@ class App(object):
         """
         return Request(
             base=f"{self.api.base_url}/{self.name}/custom-field-choices/",
-            token=self.api.token,
+            auth_header=self.api.auth_header,
             http_session=self.api.http_session,
         ).get()
 
@@ -201,7 +201,7 @@ class App(object):
                 self.api.base_url,
                 self.name,
             ),
-            token=self.api.token,
+            auth_header=self.api.auth_header,
             http_session=self.api.http_session,
         ).get()
         return config
@@ -241,7 +241,7 @@ class PluginsApp(object):
             base="{}/plugins/installed-plugins".format(
                 self.api.base_url,
             ),
-            token=self.api.token,
+            auth_header=self.api.auth_header,
             http_session=self.api.http_session,
         ).get()
         return installed_plugins

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -54,7 +54,7 @@ class Endpoint(object):
         self.name = name.replace("_", "-")
         self.api = api
         self.base_url = api.base_url
-        self.token = api.token
+        self.auth_header = api.auth_header
         self.url = "{base_url}/{app}/{endpoint}".format(
             base_url=self.base_url,
             app=app.name,
@@ -101,7 +101,7 @@ class Endpoint(object):
         api_version = api_version or self.api.api_version
         req = Request(
             base="{}/".format(self.url),
-            token=self.token,
+            auth_header=self.auth_header,
             http_session=self.api.http_session,
             threading=self.api.threading,
             max_workers=self.api.max_workers,
@@ -166,7 +166,7 @@ class Endpoint(object):
         req = Request(
             key=key,
             base=self.url,
-            token=self.token,
+            auth_header=self.auth_header,
             http_session=self.api.http_session,
             api_version=api_version,
         )
@@ -237,7 +237,7 @@ class Endpoint(object):
         req = Request(
             filters=kwargs,
             base=self.url,
-            token=self.token,
+            auth_header=self.auth_header,
             http_session=self.api.http_session,
             threading=self.api.threading,
             api_version=api_version,
@@ -302,7 +302,7 @@ class Endpoint(object):
 
         req = Request(
             base=self.url,
-            token=self.token,
+            auth_header=self.auth_header,
             http_session=self.api.http_session,
             api_version=api_version,
         ).post(args[0] if args else kwargs)
@@ -338,7 +338,7 @@ class Endpoint(object):
         req = Request(
             key=id,
             base=self.url,
-            token=self.api.token,
+            auth_header=self.api.auth_header,
             http_session=self.api.http_session,
             api_version=self.api.api_version,
         )
@@ -385,7 +385,7 @@ class Endpoint(object):
 
         req = Request(
             base=self.url,
-            token=self.api.token,
+            auth_header=self.api.auth_header,
             http_session=self.api.http_session,
             api_version=api_version,
         ).options()
@@ -442,7 +442,7 @@ class Endpoint(object):
         api_version = api_version or self.api.api_version
 
         ret = Request(
-            filters=kwargs, base=self.url, token=self.token, http_session=self.api.http_session, api_version=api_version
+            filters=kwargs, base=self.url, auth_header=self.auth_header, http_session=self.api.http_session, api_version=api_version
         )
 
         return ret.get_count()
@@ -462,7 +462,7 @@ class DetailEndpoint(object):
 
         self.request_kwargs = dict(
             base=self.url,
-            token=parent_obj.api.token,
+            auth_header=parent_obj.api.auth_header,
             http_session=parent_obj.api.http_session,
         )
 
@@ -560,7 +560,7 @@ class JobsEndpoint(Endpoint):
 
         req = Request(
             base=job_run_url,
-            token=self.token,
+            auth_header=self.auth_header,
             http_session=self.api.http_session,
             api_version=api_version,
         ).post(args[0] if args else kwargs)

--- a/pynautobot/core/query.py
+++ b/pynautobot/core/query.py
@@ -132,6 +132,7 @@ class Request(object):
         filters=None,
         key=None,
         token=None,
+        auth_header=None,
         threading=False,
         max_workers=4,
         api_version=None,
@@ -152,6 +153,10 @@ class Request(object):
         self.filters = filters
         self.key = key
         self.token = token
+        if auth_header:
+            self.auth_header = auth_header
+        else:
+            self.auth_header = f"Token {self.token}"
         self.http_session = http_session
         self.url = self.base if not key else "{}{}/".format(self.base, key)
         self.threading = threading
@@ -214,8 +219,8 @@ class Request(object):
         :Raises: RequestError if request is not successful.
         """
         headers = {"Content-Type": "application/json;"}
-        if self.token:
-            headers["authorization"] = "Token {}".format(self.token)
+        if self.auth_header:
+            headers["authorization"] = self.auth_header
 
         if self.api_version:
             headers["accept"] = f"application/json; version={self.api_version}"
@@ -246,8 +251,8 @@ class Request(object):
         else:
             headers = {"accept": "application/json;"}
 
-        if self.token:
-            headers["authorization"] = "Token {}".format(self.token)
+        if self.auth_header:
+            headers["authorization"] = self.auth_header
 
         if self.api_version:
             headers["accept"] = f"application/json; version={self.api_version}"

--- a/pynautobot/core/query.py
+++ b/pynautobot/core/query.py
@@ -171,6 +171,8 @@ class Request(object):
 
         if self.api_version:
             headers["accept"] = f"application/json; version={self.api_version}"
+        if self.auth_header:
+            headers["authorization"] = self.auth_header
 
         try:
             req = self.http_session.get(
@@ -198,7 +200,8 @@ class Request(object):
         headers = {"Content-Type": "application/json;"}
         if self.api_version:
             headers["accept"] = f"application/json; version={self.api_version}"
-
+        if self.auth_header:
+            headers["authorization"] = self.auth_header
         try:
             req = self.http_session.get(
                 self.normalize_url(self.base),

--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -298,7 +298,7 @@ class Record(object):
         if self.url:
             req = Request(
                 base=self.url,
-                token=self.api.token,
+                auth_header=self.api.auth_header,
                 http_session=self.api.http_session,
                 api_version=self.api.api_version,
             )
@@ -385,7 +385,7 @@ class Record(object):
                 req = Request(
                     key=self.id,
                     base=self.endpoint.url,
-                    token=self.api.token,
+                    auth_header=self.api.auth_header,
                     http_session=self.api.http_session,
                     api_version=self.api.api_version,
                 )
@@ -433,7 +433,7 @@ class Record(object):
         req = Request(
             key=self.id,
             base=self.endpoint.url,
-            token=self.api.token,
+            auth_header=self.api.auth_header,
             http_session=self.api.http_session,
             api_version=self.api.api_version,
         )

--- a/pynautobot/models/dcim.py
+++ b/pynautobot/models/dcim.py
@@ -28,7 +28,7 @@ class TraceableRecord(Record):
         req = Request(
             key=str(self.id) + "/trace",
             base=self.endpoint.url,
-            token=self.api.token,
+            auth_header=self.api.auth_header,
             http_session=self.api.http_session,
         )
         uri_to_obj_class_map = {

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -6,9 +6,9 @@ from pynautobot.core.query import Request
 
 class RequestTestCase(unittest.TestCase):
     def test_get_openapi(self):
-        test = Request("http://localhost:8080/api", Mock())
+        test = Request("http://localhost:8080/api", Mock(), token="1234")
         test.get_openapi()
         test.http_session.get.assert_called_with(
             "http://localhost:8080/api/docs/?format=openapi",
-            headers={"Content-Type": "application/json;"},
+            headers={"Content-Type": "application/json;", "Authorization": "Token 1234"},
         )


### PR DESCRIPTION
Add a `auth_header` attribute that is used verbatim as Authorization header (i.e. without prefixing `Token `). We use this to support oauth2 flows with Bearer tokens (patch for nautobot will come soon).