### PR TITLE
refactor: mismatching of signature of base method

### DIFF
--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -512,7 +512,7 @@ class DetailEndpoint(object):
 
 
 class RODetailEndpoint(DetailEndpoint):
-    def create(self, data):
+    def create(self, data=None, api_version=None):
         raise NotImplementedError("Writes are not supported for this endpoint.")
 
 


### PR DESCRIPTION
#### Description

Signature of [`create()` method in `RODetailEndpoint`](https://github.com/nautobot/pynautobot/blob/develop/pynautobot/core/endpoint.py#L515) does not match [the one in parent class `DetailEndpoint`](https://github.com/nautobot/pynautobot/blob/develop/pynautobot/core/endpoint.py#L490).

```python
...
class DetailEndpoint(object):
    ...
    def create(self, data=None, api_version=None):
        ...
``` 
vs
```python
...
class RODetailEndpoint(DetailEndpoint):
    ...
    def create(self, data):
        ...
```
Originally they matched each other, when `RODetailEndpoint` had been added (3862901bb378c77de0b4c1f38c5224f4462e0669 _Dec '18_). But later it was updated from `def create(self, data)` to `def create(self, data=None, api_version=None)` in `DetailEndpoint` base class (12305bc8b7c3f8fc42bea93e6cb1d6a4449e662d _Apr '22)_.

This potentially leads to a violation of LSP. 

___

#### Examples

Let's suppose user tries to call `create()` of `RODetailEndpoint` passing `api_version`.

_Expected behavior:_
```python
>>> ro_endpoint.create({"what": "ever"}, api_version="1.2.3")
Traceback (most recent call last):
  ...
NotImplementedError: Writes are not supported for this endpoint.
```
(user discovers he's trying to call not supported method)

_Current behavior:_
```python
>>> ro_endpoint.create({"what": "ever"}, api_version="1.2.3")
Traceback (most recent call last):
  ...
TypeError: RODetailEndpoint.create() got an unexpected keyword argument 'api_version'
```
(user encounters on TypeError instead)

___

* (refactor): update signature of `create()` in `RODetailEndpoint` class, make it match the one in `DetailEndpoint` base class