### PR TITLE
add support for setting a HTTP user agent

### DIFF
--- a/docs/advanced/session.rst
+++ b/docs/advanced/session.rst
@@ -13,22 +13,21 @@ A few examples are provided below:
 Headers
 -------
 
-Adding or updating headers is done by updating the ``headers`` dictionary on the ``http_response`` object.
-The example below shows how to update a Token if it has been cycled.
+HTTP headers can be modified using the ``headers`` argument, which is a dictionary of all key/value pairs. The example below shows how to set a custom user agent.
 
 .. code-block:: python
 
-    import os
     from pynautobot import api
+
+    headers = {
+        "User-Agent": "my-user-agent"
+    }
 
     nautobot = api(
         url='http://localhost:8000',
-        token=os.environ["NAUTOBOT_TOKEN"]
+        token=os.environ["NAUTOBOT_TOKEN"],
+        headers=headers
     )
-    new_token = f"Token {os.environ['NEW_NAUTOBOT_TOKEN']}"
-
-    # Update Session object with new header
-    nautobot.http_session.headers["Authorization"] = new_token
 
 SSL Verification
 ----------------

--- a/pynautobot/core/api.py
+++ b/pynautobot/core/api.py
@@ -62,7 +62,7 @@ class Api(object):
     :param int,optional retries: Number of retries, for HTTP codes 429, 500, 502, 503, 504,
         this client will try before dropping.
     :param bool,optional verify: SSL cert verification.
-    :param dict,optional headers: Set add additional HTTP headers
+    :param dict,optional headers: Override default or add additional HTTP headers
     :raises AttributeError: If app doesn't exist.
     :Examples:
 

--- a/pynautobot/core/api.py
+++ b/pynautobot/core/api.py
@@ -62,6 +62,7 @@ class Api(object):
     :param int,optional retries: Number of retries, for HTTP codes 429, 500, 502, 503, 504,
         this client will try before dropping.
     :param bool,optional verify: SSL cert verification.
+    :param str,optional http_user_agent: Override the default User-Agent used for HTTP requests
     :raises AttributeError: If app doesn't exist.
     :Examples:
 
@@ -82,6 +83,7 @@ class Api(object):
         api_version=None,
         retries=0,
         verify=True,
+        http_user_agent=None,
     ):
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
@@ -103,6 +105,8 @@ class Api(object):
         self.threading = threading
         self.max_workers = max_workers
         self.api_version = api_version
+        if http_user_agent:
+            self.http_session.headers.update({"User-Agent": http_user_agent})
 
         self.dcim = App(self, "dcim")
         self.ipam = App(self, "ipam")

--- a/pynautobot/core/api.py
+++ b/pynautobot/core/api.py
@@ -62,7 +62,7 @@ class Api(object):
     :param int,optional retries: Number of retries, for HTTP codes 429, 500, 502, 503, 504,
         this client will try before dropping.
     :param bool,optional verify: SSL cert verification.
-    :param str,optional http_user_agent: Override the default User-Agent used for HTTP requests
+    :param dict,optional headers: Set add additional HTTP headers
     :raises AttributeError: If app doesn't exist.
     :Examples:
 
@@ -83,11 +83,13 @@ class Api(object):
         api_version=None,
         retries=0,
         verify=True,
-        http_user_agent=None,
+        headers=None,
     ):
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
         self.headers = {"Authorization": f"Token {self.token}"}
+        if headers:
+            self.headers.update(**headers)
         self.base_url = base_url
         self.http_session = requests.Session()
         self.http_session.verify = verify
@@ -105,8 +107,8 @@ class Api(object):
         self.threading = threading
         self.max_workers = max_workers
         self.api_version = api_version
-        if http_user_agent:
-            self.http_session.headers.update({"User-Agent": http_user_agent})
+        if headers:
+            self.http_session.headers.update(**headers)
 
         self.dcim = App(self, "dcim")
         self.ipam = App(self, "ipam")


### PR DESCRIPTION
This PR adds support for specifying a HTTP user agent string. 

Rationale: in our codebase we try to set user agent strings to the script calling the API. This makes it easier to track down which scripts on which machines use specific APIs, which can become quite difficult to figure out on machines behind NAT and with many different scripts and users on them.