### PR TITLE
Fixes pynautobot for v1.6.16 auth changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-        nautobot-version: ["1.2", "1.3", "1.6"]
-        exclude:
-          - python-version: 3.10
-            nautobot-version: 1.2
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        nautobot-version: ["1.6"]
     env:
       PYTHON_VER: "${{ matrix.python-version }}"
       NAUTOBOT_VER: "${{ matrix.nautobot-version }}"

--- a/pynautobot/core/api.py
+++ b/pynautobot/core/api.py
@@ -15,6 +15,7 @@ limitations under the License.
 
 This file has been modified by NetworktoCode, LLC.
 """
+
 from packaging import version
 import requests
 from requests.adapters import HTTPAdapter
@@ -140,10 +141,12 @@ class Api(object):
         '1.0'
         >>>
         """
-        version = Request(
-            base=self.base_url, http_session=self.http_session, api_version=self.api_version
+        return Request(
+            base=self.base_url,
+            http_session=self.http_session,
+            api_version=self.api_version,
+            token=self.token,
         ).get_version()
-        return version
 
     def openapi(self):
         """Returns the OpenAPI spec.
@@ -166,6 +169,7 @@ class Api(object):
             base=self.base_url,
             http_session=self.http_session,
             api_version=self.api_version,
+            token=self.token,
         ).get_openapi()
 
     def status(self):
@@ -196,10 +200,9 @@ class Api(object):
          'rq-workers-running': 1}
         >>>
         """
-        status = Request(
+        return Request(
             base=self.base_url,
             token=self.token,
             http_session=self.http_session,
             api_version=self.api_version,
         ).get_status()
-        return status

--- a/pynautobot/core/query.py
+++ b/pynautobot/core/query.py
@@ -15,6 +15,7 @@ limitations under the License.
 
 This file has been modified by NetworktoCode, LLC.
 """
+
 try:
     import concurrent.futures as cf
 except ImportError:
@@ -162,6 +163,7 @@ class Request(object):
         """Gets the OpenAPI Spec"""
         headers = {
             "Content-Type": "application/json;",
+            "Authorization": f"Token {self.token}",
         }
 
         if self.api_version:
@@ -190,7 +192,10 @@ class Request(object):
         :Returns: Version number as a string. Empty string if version is not
         present in the headers.
         """
-        headers = {"Content-Type": "application/json;"}
+        headers = {
+            "Content-Type": "application/json;",
+            "Authorization": f"Token {self.token}",
+        }
         if self.api_version:
             headers["accept"] = f"application/json; version={self.api_version}"
 
@@ -213,7 +218,10 @@ class Request(object):
         :Returns: Dictionary as returned by Nautobot.
         :Raises: RequestError if request is not successful.
         """
-        headers = {"Content-Type": "application/json;"}
+        headers = {
+            "Content-Type": "application/json;",
+            "Authorization": f"Token {self.token}",
+        }
         if self.token:
             headers["authorization"] = "Token {}".format(self.token)
 

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -6,9 +6,9 @@ from pynautobot.core.query import Request
 
 class RequestTestCase(unittest.TestCase):
     def test_get_openapi(self):
-        test = Request("http://localhost:8080/api", Mock())
+        test = Request("http://localhost:8080/api", Mock(), token="1234")
         test.get_openapi()
         test.http_session.get.assert_called_with(
             "http://localhost:8080/api/docs/?format=openapi",
-            headers={"Content-Type": "application/json;"},
+            headers={"Content-Type": "application/json;", "Authorization": "Token 1234"},
         )


### PR DESCRIPTION
v1 fix for #172 

This PR adds the token to status, version and openapi calls. I also updated our CI to only test nautobot v1.6 as well as added python 3.11.