### PR TITLE
Updates so that docs build on RTD correctly

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,20 +1,22 @@
 ---
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
 
-# Patch to get docs building in current pattern
+# Set the version of Python in the build environment.
 build:
   os: "ubuntu-22.04"
   tools:
     python: "3.10"
 
-sphinx:
-  builder: "html"
-  configuration: "docs/conf.py"
-  fail_on_warning: false
+mkdocs:
+  configuration: "mkdocs.yml"
+  fail_on_warning: true
 
+# Use our docs/requirements.txt during installation.
 python:
   install:
-    - method: "pip"
-      path: "."
-      extra_requirements:
-        - "docs"
+    - requirements: "docs/requirements.txt"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ build:
 
 mkdocs:
   configuration: "mkdocs.yml"
-  fail_on_warning: true
+  fail_on_warning: false
 
 # Use our docs/requirements.txt during installation.
 python:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,8 @@
 mkdocs==1.5.2
 # Material for MkDocs theme
-mkdocs-material==9.2.4
-mkdocs-python-classy==0.1.3
+mkdocs-material==9.5.19
 # Render custom markdown for version added/changed/remove notes
 mkdocs-version-annotations==1.0.0
 # Automatic documentation from sources, for MkDocs
-mkdocstrings==0.22.0
-mkdocstrings-python==1.6.0
+mkdocstrings==0.24.3
+mkdocstrings-python==1.10.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ mkdocs-version-annotations==1.0.0
 # Automatic documentation from sources, for MkDocs
 mkdocstrings==0.24.3
 mkdocstrings-python==1.10.0
+markdown-data-tables==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.5.2
+mkdocs==1.6.0
 # Material for MkDocs theme
 mkdocs-material==9.5.19
 # Render custom markdown for version added/changed/remove notes


### PR DESCRIPTION
`docs/requirements.txt` should be kept in sync with the versions used in the `pyproject.toml` for poetry. In the apps cookiecutter we actually pin them down to a specific version since that's the only way to keep these two files in perfect sync (and tests!): https://github.com/nautobot/cookiecutter-nautobot-app/blob/develop/nautobot-app/%7B%7B%20cookiecutter.project_slug%20%7D%7D/pyproject.toml

I would personally avoid relying on `^` version specs, especially since some of the docs packages don't do semver - mkdocs-material makes breaking changes randomly between major and minor bumps (I have been bit by it in the past), mkdocstrings is still at 0.x (so breaking changes happen in minors) etc.

The mkdocstrings griffe parser produces a lot of docstrings-related warnings, which forced me to remove strict mode in mkdocs builds. Would be good to fix those.