### PR TITLE
chore: Update pkg_resources to use importlib.metadata

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@
 #
 import os
 import sys
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
 sys.path.insert(0, os.path.abspath("../"))
 
@@ -69,7 +69,7 @@ author = "Network to Code"  # "Zach Moody"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 # The full version, including alpha/beta/rc tags.
-release = get_distribution("pynautobot").version
+release = version("pynautobot")
 #
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])

--- a/pynautobot/__init__.py
+++ b/pynautobot/__init__.py
@@ -2,15 +2,15 @@
 This file has been modified by NetworktoCode, LLC.
 """
 
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import PackageNotFoundError, version
 
-from pynautobot.core.query import RequestError, AllocationError, ContentError
 from pynautobot.core.api import Api as api
+from pynautobot.core.query import AllocationError, ContentError, RequestError
 
+__all__ = ["RequestError", "AllocationError", "ContentError", "api", "__version__"]
 
-__all__ = ["RequestError", "AllocationError", "ContentError", "api"]
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__package__)
+except PackageNotFoundError:
     pass


### PR DESCRIPTION
This replaces the use of pkg_resources with `importlib.metadata`.

Some research notes:
- `importlib.metadata` has been available since python 3.8
- `pkg_resources` is deprecated in python 3.11 (and pytest will report a warning)
- `pkg_resources` is absent in python 3.12 (and pytest will fail)