### PR TITLE
fix(Record): Cast Record.__str__ return to str

### DIFF
--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -202,7 +202,7 @@ class Record(object):
         return dict(self)[k]
 
     def __str__(self):
-        return getattr(self, "display", None) or getattr(self, "name", None) or getattr(self, "label", None) or ""
+        return str(getattr(self, "display", None) or getattr(self, "name", None) or getattr(self, "label", None) or "")
 
     def __repr__(self):
         return "<{}.{} ('{}') at {}>".format(self.__class__.__module__, self.__class__.__name__, self, hex(id(self)))


### PR DESCRIPTION
## New Pull Request

Have you:
- [ ] Updated the README if necessary?
- [ ] Updated any configuration settings?
- [ ] Written a unit test?

## Change Notes

## Justification

Cast Record.__str__ to string before returning.

For us, this fixes cases where `name` on a custom object is an integer and repr(obj) is called.