### PR TITLE
Fixed issue where circuit details are not known without fetching them

### DIFF
--- a/pynautobot/models/dcim.py
+++ b/pynautobot/models/dcim.py
@@ -213,16 +213,12 @@ class Termination(Record):
         # hacky check to see if we're a circuit termination to
         # avoid another call to Nautobot because of a non-existent attr
         # in self.name
-        # Fetch details for the circuit if it doesn't have them
         if "circuit" in str(self.url):
-            if not self.has_details:
-                self.full_details()
             return self.circuit.cid
 
         return self.name
 
     device = Devices
-    circuit = Circuits
 
 
 class Cables(Record):

--- a/pynautobot/models/dcim.py
+++ b/pynautobot/models/dcim.py
@@ -213,7 +213,10 @@ class Termination(Record):
         # hacky check to see if we're a circuit termination to
         # avoid another call to Nautobot because of a non-existent attr
         # in self.name
+        # Fetch details for the circuit if it doesn't have them
         if "circuit" in str(self.url):
+            if not self.has_details:
+                self.full_details()
             return self.circuit.cid
 
         return self.name

--- a/pynautobot/models/dcim.py
+++ b/pynautobot/models/dcim.py
@@ -19,7 +19,6 @@ from requests.utils import urlparse
 from pynautobot.core.query import Request
 from pynautobot.core.response import Record, JsonField
 from pynautobot.core.endpoint import RODetailEndpoint
-from pynautobot.models.circuits import Circuits
 
 
 class TraceableRecord(Record):

--- a/pynautobot/models/dcim.py
+++ b/pynautobot/models/dcim.py
@@ -19,6 +19,7 @@ from requests.utils import urlparse
 from pynautobot.core.query import Request
 from pynautobot.core.response import Record, JsonField
 from pynautobot.core.endpoint import RODetailEndpoint
+from pynautobot.models.circuits import Circuits
 
 
 class TraceableRecord(Record):
@@ -209,15 +210,10 @@ class Racks(Record):
 
 class Termination(Record):
     def __str__(self):
-        # hacky check to see if we're a circuit termination to
-        # avoid another call to Nautobot because of a non-existent attr
-        # in self.name
-        if "circuit" in str(self.url):
-            return self.circuit.cid
-
-        return self.name
+        return self.display
 
     device = Devices
+    circuit = Circuits
 
 
 class Cables(Record):

--- a/tests/fixtures/dcim/cable.json
+++ b/tests/fixtures/dcim/cable.json
@@ -12,7 +12,8 @@
             "display_name": "tst1-test1"
         },
         "name": "Console",
-        "cable": 1
+        "cable": 1,
+        "display": "foo"
     },
     "termination_b_type": "dcim.consoleserverport",
     "termination_b_id": 2,
@@ -26,7 +27,8 @@
             "display_name": "tst1-test2"
         },
         "name": "Port 10",
-        "cable": 1
+        "cable": 1,
+        "display": "foo"
     },
     "type": null,
     "status": {

--- a/tests/fixtures/dcim/cables.json
+++ b/tests/fixtures/dcim/cables.json
@@ -17,7 +17,8 @@
                     "display_name": "tst1-test1"
                 },
                 "name": "Console",
-                "cable": 1
+                "cable": 1,
+                "display": "foo"
             },
             "termination_b_type": "dcim.consoleserverport",
             "termination_b_id": 2,
@@ -31,7 +32,8 @@
                     "display_name": "tst1-test2"
                 },
                 "name": "Port 10",
-                "cable": 1
+                "cable": 1,
+                "display": "foo"
             },
             "type": null,
             "status": {
@@ -57,7 +59,8 @@
                     "display_name": "tst1-test3"
                 },
                 "name": "Console",
-                "cable": 2
+                "cable": 2,
+                "display": "foo"
             },
             "termination_b_type": "dcim.consoleserverport",
             "termination_b_id": 4,
@@ -71,7 +74,8 @@
                     "display_name": "tst1-test4"
                 },
                 "name": "Port 11",
-                "cable": 2
+                "cable": 2,
+                "display": "foo"
             },
             "type": null,
             "status": {
@@ -97,7 +101,8 @@
                     "display_name": "tst1-test5"
                 },
                 "name": "Console",
-                "cable": 3
+                "cable": 3,
+                "display": "foo"
             },
             "termination_b_type": "dcim.consoleserverport",
             "termination_b_id": 6,
@@ -111,7 +116,8 @@
                     "display_name": "tst1-test6"
                 },
                 "name": "Port 1",
-                "cable": 3
+                "cable": 3,
+                "display": "foo"
             },
             "type": null,
             "status": {

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -354,7 +354,7 @@ class CablesTestCase(Generic.Tests):
                         "url": "http://localhost:8000/api/circuits/circuits/1/",
                     },
                     "term_side": "A",
-                    "display": "TEST123321"
+                    "display": "TEST123321",
                 },
                 "termination_b_type": "dcim.interface",
                 "termination_b_id": 2,

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -340,7 +340,7 @@ class CablesTestCase(Generic.Tests):
     app = "dcim"
     name = "cables"
 
-    def test_get_circuit(self):
+    def test_get_cable_between_device_and_circuit(self):
         response_obj = Response(
             content={
                 "id": self.uuid,
@@ -352,9 +352,9 @@ class CablesTestCase(Generic.Tests):
                     "circuit": {
                         "id": 346,
                         "url": "http://localhost:8000/api/circuits/circuits/1/",
-                        "cid": "TEST123321",
                     },
                     "term_side": "A",
+                    "display": "TEST123321"
                 },
                 "termination_b_type": "dcim.interface",
                 "termination_b_id": 2,
@@ -368,6 +368,7 @@ class CablesTestCase(Generic.Tests):
                         "display_name": "tst1-test2",
                     },
                     "name": "xe-0/0/0",
+                    "display": "xe-0/0/0",
                     "cable": 1,
                 },
                 "type": None,


### PR DESCRIPTION
This closes #222.  

The other termination type includes the identifier `name` in the original API call, so it's not an issue.  For a circuit termination type, the identifier `circuit.cid` is not in the original API call.  That's why an additional fetch is necessary.  

Pynautobot usually handles this with the `__getattr__` method.  However, this does not work in this case because the `Circuit` object has not been initialized yet.   Once initialized via `full_details()`, the `__getattr__` works as expected.  

Another solution was to increase the `depth` param on the API call, but it added performance overhead that wasn't ideal.  