### PR TITLE
Added graphql run method for query objects

### DIFF
--- a/docs/user/advanced/graphql.md
+++ b/docs/user/advanced/graphql.md
@@ -118,6 +118,46 @@ location name is now derived using variables.
 GraphQLRecord(json={'data': {'locations': [{'id': ..., 'name': 'HQ', 'parent': {'name': 'US'}}]}}, status_code=200)
 ```
 
+## Making a GraphQL Query with a Saved Query
+
+Nautobot supports saving your graphql queries and executing them later.
+Here is an example of saving a query using pynautobot.
+
+```python
+>>> query = """
+... query ($location_name:String!) {
+...   locations (name: [$location_name]) {
+...     id
+...     name
+...     parent {
+...       name
+...     }
+...   }
+... }
+... """
+>>> data = {"name": "Foobar", "query": query}
+>>> nautobot.extras.graphql_queries.create(**data)
+```
+
+Now that we have a query saved with the name `Foobar`, we can execute it using pynautobot.
+
+```python
+>>> # Create a variables dictionary
+>>> variables = {"location_name": "HQ"}
+>>>
+>>> # Get the query object that was created
+>>> query_object = nautobot.extras.graphql_queries.get("Foobar")
+>>>
+>>> # Call the run method to execute query
+>>> query_object.run()
+>>>
+>>> # To execute a query with variables
+>>> query_object.run(variables=variables)
+>>>
+>>> # To execute a query with custom payload
+>>> query_object.run({"variables": variables, "foo": "bar"})
+```
+
 ## The GraphQLRecord Object
 
 The `~pynautobot.core.graphql.GraphQLRecord`{.interpreted-text

--- a/pynautobot/core/app.py
+++ b/pynautobot/core/app.py
@@ -16,7 +16,7 @@
 
 import logging
 
-from pynautobot.core.endpoint import Endpoint, JobsEndpoint
+from pynautobot.core.endpoint import Endpoint, JobsEndpoint, GraphqlEndpoint
 from pynautobot.core.query import Request
 from pynautobot.models import circuits, dcim, extras, ipam, users, virtualization
 
@@ -63,6 +63,8 @@ class App(object):
     def __getattr__(self, name):
         if name == "jobs":
             return JobsEndpoint(self.api, self, name, model=self.model)
+        elif name == "graphql_queries":
+            return GraphqlEndpoint(self.api, self, name, model=self.model)
         return Endpoint(self.api, self, name, model=self.model)
 
     def __dir__(self):

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -695,7 +695,7 @@ class JobsEndpoint(Endpoint):
 class GraphqlEndpoint(Endpoint):
     """Extend Endpoint class to support run method for graphql queries."""
 
-    def run(self, *args, query_id=None, **kwargs):
+    def run(self, query_id, *args, **kwargs):
         """Runs a saved graphql query based on the query_id provided.
 
         Takes a kwarg of `query_id` to specify the query that should be run.
@@ -728,11 +728,7 @@ class GraphqlEndpoint(Endpoint):
                     {"variables":{"foo":"bar"}}
                 )
         """
-
-        if not query_id:
-            raise ValueError('Keyword Argument "query_id" is required to run a query.')
         query_run_url = f"{self.url}/{query_id}/run/"
-
         return Request(
             base=query_run_url,
             token=self.token,

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -690,3 +690,39 @@ class JobsEndpoint(Endpoint):
         ).post(args[0] if args else kwargs)
 
         return response_loader(req, self.return_obj, self)
+
+
+class GraphqlEndpoint(Endpoint):
+    """Extend Endpoint class to support run method for graphql queries."""
+
+    def run(self, *args, **kwargs):
+        """Runs a saved graphql query based on the query_id provided.
+
+        Takes a kwarg of `query_id` to specify the query that should be run.
+
+        Args:
+            *args (str, optional): Used as payload for POST method
+                to the API if provided.
+            **kwargs (str, optional): Any search argument the
+                endpoint accepts can be added as a keyword arg.
+
+        Returns:
+            An API response from the execution of the saved graphql query.
+
+        Examples:
+            To run a query with the following variables:
+            >>> query = nb.extras.graphql_queries.get("Example")
+            >>> query.run(
+                    variables={"foo": "bar"})
+                )
+        """
+
+        if not kwargs.get("query_id"):
+            raise ValueError('Keyword Argument "query_id" is required to run a query.')
+        query_run_url = f"{self.url}/{kwargs['query_id']}/run/"
+
+        return Request(
+            base=query_run_url,
+            token=self.token,
+            http_session=self.api.http_session,
+        ).post(args[0] if args else kwargs)

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -695,7 +695,7 @@ class JobsEndpoint(Endpoint):
 class GraphqlEndpoint(Endpoint):
     """Extend Endpoint class to support run method for graphql queries."""
 
-    def run(self, *args, **kwargs):
+    def run(self, *args, query_id=None, **kwargs):
         """Runs a saved graphql query based on the query_id provided.
 
         Takes a kwarg of `query_id` to specify the query that should be run.
@@ -703,23 +703,35 @@ class GraphqlEndpoint(Endpoint):
         Args:
             *args (str, optional): Used as payload for POST method
                 to the API if provided.
-            **kwargs (str, optional): Any search argument the
+            **kwargs (str, optional): Any additional argument the
                 endpoint accepts can be added as a keyword arg.
+            query_id (str, required): The UUID of the query object
+                that is being ran.
 
         Returns:
             An API response from the execution of the saved graphql query.
 
         Examples:
-            To run a query with the following variables:
+            To run a query no variables:
+            >>> query = nb.extras.graphql_queries.get("Example")
+            >>> query.run()
+
+            To run a query with `variables` as kwarg:
             >>> query = nb.extras.graphql_queries.get("Example")
             >>> query.run(
                     variables={"foo": "bar"})
                 )
+
+            To run a query with JSON payload as an arg:
+            >>> query = nb.extras.graphql_queries.get("Example")
+            >>> query.run(
+                    {"variables":{"foo":"bar"}}
+                )
         """
 
-        if not kwargs.get("query_id"):
+        if not query_id:
             raise ValueError('Keyword Argument "query_id" is required to run a query.')
-        query_run_url = f"{self.url}/{kwargs['query_id']}/run/"
+        query_run_url = f"{self.url}/{query_id}/run/"
 
         return Request(
             base=query_run_url,

--- a/pynautobot/models/extras.py
+++ b/pynautobot/models/extras.py
@@ -14,7 +14,7 @@
 #
 # This file has been modified by NetworktoCode, LLC.
 
-from pynautobot.core.endpoint import JobsEndpoint, DetailEndpoint
+from pynautobot.core.endpoint import JobsEndpoint, DetailEndpoint, GraphqlEndpoint
 from pynautobot.core.response import JsonField, Record
 
 
@@ -42,6 +42,12 @@ class Jobs(Record):
     def run(self, **kwargs):
         """Run a job from within a job instance."""
         return JobsEndpoint(self.api, self.api.extras, "jobs").run(class_path=self.id, **kwargs)
+
+
+class GraphqlQueries(Record):
+    def run(self, **kwargs):
+        """Run a graphql query from a saved graphql instance."""
+        return GraphqlEndpoint(self.api, self.api.extras, "graphql_queries").run(query_id=self.id, **kwargs)
 
 
 class DynamicGroups(Record):

--- a/pynautobot/models/extras.py
+++ b/pynautobot/models/extras.py
@@ -47,7 +47,7 @@ class Jobs(Record):
 class GraphqlQueries(Record):
     def run(self, *args, **kwargs):
         """Run a graphql query from a saved graphql instance."""
-        return GraphqlEndpoint(self.api, self.api.extras, "graphql_queries").run(query_id=self.id, *args, **kwargs)
+        return GraphqlEndpoint(self.api, self.api.extras, "graphql_queries").run(self.id, *args, **kwargs)
 
 
 class DynamicGroups(Record):

--- a/pynautobot/models/extras.py
+++ b/pynautobot/models/extras.py
@@ -45,9 +45,9 @@ class Jobs(Record):
 
 
 class GraphqlQueries(Record):
-    def run(self, **kwargs):
+    def run(self, *args, **kwargs):
         """Run a graphql query from a saved graphql instance."""
-        return GraphqlEndpoint(self.api, self.api.extras, "graphql_queries").run(query_id=self.id, **kwargs)
+        return GraphqlEndpoint(self.api, self.api.extras, "graphql_queries").run(query_id=self.id, *args, **kwargs)
 
 
 class DynamicGroups(Record):

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from pynautobot.core.endpoint import Endpoint, JobsEndpoint
+from pynautobot.core.endpoint import Endpoint, JobsEndpoint, GraphqlEndpoint
 from pynautobot.core.response import Record
 
 
@@ -248,3 +248,12 @@ class JobEndPointTestCase(unittest.TestCase):
             test_obj = JobsEndpoint(api, app, "test")
             test = test_obj.run(job_id="test")
             self.assertEqual(len(test), 1)
+
+
+class GraphqlEndPointTestCase(unittest.TestCase):
+    def test_invalid_arg(self):
+        with self.assertRaises(ValueError, msg='Keyword Argument "query_id" is required to run a query.'):
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock(name="test")
+            test_obj = GraphqlEndpoint(api, app, "test")
+            test_obj.run()

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -252,7 +252,9 @@ class JobEndPointTestCase(unittest.TestCase):
 
 class GraphqlEndPointTestCase(unittest.TestCase):
     def test_invalid_arg(self):
-        with self.assertRaises(ValueError, msg='Keyword Argument "query_id" is required to run a query.'):
+        with self.assertRaises(
+            TypeError, msg="GraphqlEndpoint.run() missing 1 required positional argument: 'query_id'"
+        ):
             api = Mock(base_url="http://localhost:8000/api")
             app = Mock(name="test")
             test_obj = GraphqlEndpoint(api, app, "test")


### PR DESCRIPTION
This would close #232 if approved.  

Usage:
```python
query = nb.extras.graphql_queries.get("example")
query.run(
    variables={"foo": "bar"})
)
```