### PR TITLE
Changed all() method to call filter() method in Endpoint class

### DIFF
--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -81,7 +81,7 @@ class Endpoint(object):
             ret = Record
         return ret
 
-    def all(self, api_version=None, limit=None, offset=None):
+    def all(self, *args, **kwargs):
         """Queries the 'ListView' of a given endpoint.
 
         Returns all objects from an endpoint.
@@ -101,21 +101,7 @@ class Endpoint(object):
             >>> nb.dcim.devices.all()
             [test1-a3-oobsw2, test1-a3-oobsw3, test1-a3-oobsw4]
         """
-        if not limit and offset is not None:
-            raise ValueError("offset requires a positive limit value")
-        api_version = api_version or self.api.api_version
-        req = Request(
-            base="{}/".format(self.url),
-            token=self.token,
-            http_session=self.api.http_session,
-            threading=self.api.threading,
-            max_workers=self.api.max_workers,
-            api_version=api_version,
-            limit=limit,
-            offset=offset,
-        )
-
-        return response_loader(req.get(), self.return_obj, self)
+        return self.filter(*args, **kwargs)
 
     def get(self, *args, **kwargs):
         """Queries the DetailsView of a given endpoint.
@@ -222,8 +208,6 @@ class Endpoint(object):
         if args:
             kwargs.update({"q": args[0]})
 
-        if not kwargs:
-            raise ValueError("filter must be passed kwargs. Perhaps use all() instead.")
         if any(i in RESERVED_KWARGS for i in kwargs):
             raise ValueError("A reserved {} kwarg was passed. Please remove it " "try again.".format(RESERVED_KWARGS))
         limit = kwargs.pop("limit") if "limit" in kwargs else None

--- a/tests/integration/test_dcim.py
+++ b/tests/integration/test_dcim.py
@@ -183,6 +183,7 @@ class TestSimpleServerRackingAndConnecting:
             role={"name": "Leaf Switch"},
             location=location.id,
             status={"name": "Active"},
+            local_config_context_data={"foo": "bar"},
         )
         vc = nb_client.dcim.virtual_chassis.create(name="VC1", master=dev1.id)
         nb_client.dcim.devices.create(
@@ -193,6 +194,7 @@ class TestSimpleServerRackingAndConnecting:
             status={"name": "Active"},
             virtual_chassis=vc.id,
             vc_position=2,
+            local_config_context_data={"foo": "bar"},
         )
         all_vcs = nb_client.dcim.virtual_chassis.all()
         assert len(all_vcs) == 1

--- a/tests/integration/test_endpoint.py
+++ b/tests/integration/test_endpoint.py
@@ -1,3 +1,19 @@
+class TestEndpoint:
+    """Verify different methods on an endpoint."""
+
+    def test_get_all_devices(self, nb_client):
+        devices = nb_client.dcim.devices.all()
+        assert len(devices) == 8
+
+    def test_get_all_devices_include_context(self, nb_client):
+        devices = nb_client.dcim.devices.all(name="dev-1", include=["config_context"])
+        assert devices[0].config_context == {"foo": "bar"}
+
+    def test_get_filtered_devices(self, nb_client):
+        devices = nb_client.dcim.devices.filter(device_type="DCS-7050TX3-48C8")
+        assert len(devices) == 6
+
+
 class TestPagination:
     """Verify we can limit and offset results on an endpoint."""
 

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -15,13 +15,6 @@ class EndPointTestCase(unittest.TestCase):
             test = test_obj.filter(test="test")
             self.assertEqual(len(test), 2)
 
-    def test_filter_empty_kwargs(self):
-        api = Mock(base_url="http://localhost:8000/api")
-        app = Mock(name="test")
-        test_obj = Endpoint(api, app, "test")
-        with self.assertRaises(ValueError) as _:
-            test_obj.filter()
-
     def test_filter_reserved_kwargs(self):
         api = Mock(base_url="http://localhost:8000/api")
         app = Mock(name="test")
@@ -37,6 +30,22 @@ class EndPointTestCase(unittest.TestCase):
             test_obj = Endpoint(api, app, "test")
             with self.assertRaises(ValueError) as _:
                 test_obj.all(limit=None, offset=1)
+
+    def test_all_equals_filter_empty_kwargs(self):
+        with patch("pynautobot.core.query.Request.get", return_value=Mock()) as mock:
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock(name="test")
+            mock.return_value = [{"id": 123}, {"id": 321}]
+            test_obj = Endpoint(api, app, "test")
+            self.assertEqual(test_obj.all(), test_obj.filter())
+
+    def test_all_accepts_kwargs(self):
+        with patch("pynautobot.core.endpoint.Endpoint.filter", return_value=Mock()) as mock:
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock(name="test")
+            test_obj = Endpoint(api, app, "test")
+            test_obj.all(include=["config_context"])
+            mock.assert_called_with(include=["config_context"])
 
     def test_filter_zero_limit_offset(self):
         with patch("pynautobot.core.query.Request.get", return_value=Mock()) as mock:


### PR DESCRIPTION
This would close #237 if approved

Added tests to confirm context could be retrieved with the following:

```python
nautobot.dcim.devices.all(include=['config_context'])
```