### PR TITLE
Added cloud models and appropriate JSON fields to fix #252

### DIFF
--- a/pynautobot/models/cloud.py
+++ b/pynautobot/models/cloud.py
@@ -14,4 +14,30 @@
 #
 # This file has been modified by NetworktoCode, LLC.
 
-# Reserved for cloud models
+from pynautobot.core.response import Record, JsonField
+
+
+class CloudResourceTypes(Record):
+    """
+    CloudResourceType object
+    """
+
+    config_schema = JsonField
+
+
+class CloudServices(Record):
+    """
+    CloudService object
+    """
+
+    extra_config = JsonField
+    cloud_resource_type = CloudResourceTypes
+
+
+class CloudNetworks(Record):
+    """
+    CloudNetwork object
+    """
+
+    extra_config = JsonField
+    cloud_resource_type = CloudResourceTypes

--- a/tests/integration/test_cloud.py
+++ b/tests/integration/test_cloud.py
@@ -20,9 +20,12 @@ class TestCloudResourceType:
 
         # Create
         cloud_resource_type = nb_client.cloud.cloud_resource_types.create(
-            name="Test", provider="Dell", content_types=["cloud.cloudservice"]
+            name="Test", provider="Dell", content_types=["cloud.cloudservice"], config_schema={"Foo": "Bar"}
         )
         assert cloud_resource_type
+
+        # Confirm json field is retrievable
+        assert cloud_resource_type.config_schema == {"Foo": "Bar"}
 
         # Read
         test_cloud_resource_type = nb_client.cloud.cloud_resource_types.get(name="Test")
@@ -72,9 +75,12 @@ class TestCloudResourceType:
         )
         cloud_account = nb_client.cloud.cloud_accounts.create(name="TestAcct", provider="Dell", account_number="424242")
         cloud_service = nb_client.cloud.cloud_services.create(
-            name="TestService", cloud_resource_type="Test", cloud_account="TestAcct"
+            name="TestService", cloud_resource_type="Test", cloud_account="TestAcct", extra_config={"Foo": "Bar"}
         )
         assert cloud_service
+
+        # Confirm json field is retrievable
+        assert cloud_service.extra_config == {"Foo": "Bar"}
 
         # Read
         test_cloud_service = nb_client.cloud.cloud_services.get(name="TestService")
@@ -105,9 +111,12 @@ class TestCloudResourceType:
         )
         cloud_account = nb_client.cloud.cloud_accounts.create(name="TestAcct", provider="Dell", account_number="424242")
         cloud_network = nb_client.cloud.cloud_networks.create(
-            name="TestNetwork", cloud_resource_type="Test", cloud_account="TestAcct"
+            name="TestNetwork", cloud_resource_type="Test", cloud_account="TestAcct", extra_config={"Foo": "Bar"}
         )
         assert cloud_network
+
+        # Confirm json field is retrievable
+        assert cloud_network.extra_config == {"Foo": "Bar"}
 
         # Read
         test_cloud_network = nb_client.cloud.cloud_networks.get(name="TestNetwork")


### PR DESCRIPTION
Fixes bug where json fields would not be collected from the response for new cloud models.  Closes #252.

Issue arises from this block of code.  If class does not have the `_json_field` attribute set to True, then it's skipped.  

https://github.com/nautobot/pynautobot/blob/84f28a53dd9d581a088f1d4115a7e9f7e76ad135/pynautobot/core/response.py#L253-L260