### PR TITLE
Added json field of filter to dynamic groups

### DIFF
--- a/pynautobot/models/extras.py
+++ b/pynautobot/models/extras.py
@@ -51,6 +51,8 @@ class GraphqlQueries(Record):
 
 
 class DynamicGroups(Record):
+    filter = JsonField
+
     def __str__(self):
         parent_record_string = super().__str__()
         return parent_record_string or str(self.id)

--- a/tests/integration/test_extras.py
+++ b/tests/integration/test_extras.py
@@ -91,7 +91,7 @@ class TestDynamicGroup:
     """Dynamic group tests."""
 
     def test_dynamic_group_filter_field(self, nb_client):
-        """Verify we can create a dyanmic group and return the filter field."""
+        """Verify we can create a dynamic group and return the filter field."""
 
         # Define filter field
         obj_filter = {"q": "foobar"}

--- a/tests/integration/test_extras.py
+++ b/tests/integration/test_extras.py
@@ -1,5 +1,3 @@
-from packaging import version
-
 import pytest
 
 

--- a/tests/integration/test_extras.py
+++ b/tests/integration/test_extras.py
@@ -1,3 +1,5 @@
+from packaging import version
+
 import pytest
 
 
@@ -85,3 +87,31 @@ class TestGraphqlQueries:
         data = query.run(variables={"devicename": "dev-1"})
         assert len(data.get("data", {}).get("devices")) == 1
         assert data.get("data", {}).get("devices")[0].get("name") == "dev-1"
+
+
+class TestDynamicGroup:
+    """Dynamic group tests."""
+
+    def test_dynamic_group_filter_field(self, nb_client):
+        """Verify we can create a dyanmic group and return the filter field."""
+
+        # Define filter field
+        obj_filter = {"q": "foobar"}
+
+        # Create dynamic group
+        nb_client.extras.dynamic_groups.create(
+            [
+                {
+                    "name": "TestDynamicGroup",
+                    "content_type": "dcim.device",
+                    "group_type": "dynamic-filter",
+                    "filter": obj_filter,
+                }
+            ]
+        )
+
+        # Get dynamic group
+        dynamic_group = nb_client.extras.dynamic_groups.get(name="TestDynamicGroup")
+
+        # Assert filter field is returned
+        assert dynamic_group.filter == obj_filter


### PR DESCRIPTION
This is needed to properly capture the JSON field `filter` returned by the dynamic groups API.  Otherwise, it is not returned as an attribute on the response object.  Closes #258 