### PR TITLE
Fixes napalm_args parsing for platforms

### DIFF
--- a/changes/287.fixed
+++ b/changes/287.fixed
@@ -1,0 +1,1 @@
+Fixed napalm_args not being parsed correctly for platforms.

--- a/pynautobot/models/dcim.py
+++ b/pynautobot/models/dcim.py
@@ -224,3 +224,11 @@ class Cables(Record):
 
     termination_a = Termination
     termination_b = Termination
+
+
+class Platforms(Record):
+    """
+    Platform object
+    """
+
+    napalm_args = JsonField

--- a/tests/integration/test_dcim.py
+++ b/tests/integration/test_dcim.py
@@ -203,3 +203,10 @@ class TestSimpleServerRackingAndConnecting:
         assert vc1.member_count == 2
         assert vc1.master.name == dev1.name
         assert vc1.master.id == dev1.id
+
+
+def test_platform_napalm_args(nb_client):
+    """Validate napalm_args are properly returned for a platform (Issue #287)."""
+    nb_client.dcim.platforms.create(name="Arista", napalm_args={"key": "value"})
+    arista = nb_client.dcim.platforms.get(name="Arista")
+    assert arista.napalm_args == {"key": "value"}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #287

## What's Changed
Corrected `napalm_args` to be a JsonField for platforms:
```python
In [1]: from pynautobot import api

In [2]: nb = api(url="https://demo.nautobot.com/", token=40*"a")

In [3]: platform = nb.dcim.platforms.get(id="aa07ca99-b973-4870-9b44-e1ea48c23cc9")

In [4]: platform.napalm_args
Out[4]: {'global_delay_factor': 2}
```
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
