### PR TITLE
avoid using a re-exported stdlib urlparse

### DIFF
--- a/changes/294.housekeeping
+++ b/changes/294.housekeeping
@@ -1,0 +1,1 @@
+Use direct import from stdlib instead of requests re-export.

--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -18,8 +18,8 @@
 
 import copy
 from collections import OrderedDict
+from urllib.parse import urlparse
 
-from requests.utils import urlparse
 import pynautobot.core.app
 import pynautobot.core.endpoint
 from pynautobot.core.query import Request

--- a/pynautobot/models/dcim.py
+++ b/pynautobot/models/dcim.py
@@ -16,7 +16,7 @@
 #
 # This file has been modified by NetworktoCode, LLC.
 
-from requests.utils import urlparse
+from urllib.parse import urlparse
 
 from pynautobot.core.query import Request
 from pynautobot.core.response import Record, JsonField


### PR DESCRIPTION
urlparse comes from the stdlib module urllib.parse but instead the code was relying on the re-export.

## What's Changed

Internal code style cleanup.

