### PR TITLE
Fixing parameters parsing for secrets

### DIFF
--- a/changes/295.fixed
+++ b/changes/295.fixed
@@ -1,0 +1,1 @@
+Fixed `parameters` not being parsed correctly for secrets.

--- a/pynautobot/models/extras.py
+++ b/pynautobot/models/extras.py
@@ -97,3 +97,9 @@ class DynamicGroups(Record):
         [<pynautobot.models.extras.DynamicGroups ('192.168.10.200/32') at 0x7f3e6a980040>...]
         """
         return DetailEndpoint(self, "members", custom_return=DynamicGroups)
+
+
+class Secrets(Record):
+    """Secrets."""
+
+    parameters = JsonField

--- a/tests/integration/test_extras.py
+++ b/tests/integration/test_extras.py
@@ -119,3 +119,14 @@ class TestDynamicGroup:  # pylint: disable=too-few-public-methods
 
         # Assert filter field is returned
         assert dynamic_group.filter == obj_filter
+
+
+def test_secret_parameters(nb_client):
+    """Validate parameters are properly returned for secrets (Issue #295)."""
+    nb_client.extras.secrets.create(
+        name="test_secret",
+        provider="environment-variable",
+        parameters={"variable": "NAUTOBOT_NAPALM_PASSWORD"},
+    )
+    secret = nb_client.extras.secrets.get(name="test_secret")
+    assert secret.parameters == {"variable": "NAUTOBOT_NAPALM_PASSWORD"}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #295

## What's Changed
Fixing parsing of the `parameters` field for Secrets

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
