### PR TITLE
Fixing JobsEndpoint.run_and_wait status comparison

### DIFF
--- a/changes/309.fixed
+++ b/changes/309.fixed
@@ -1,0 +1,1 @@
+Fixed JobsEndpoint.run_and_wait() to properly compare the job status as a string to determine if the job is complete.

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -735,7 +735,7 @@ class JobsEndpoint(Endpoint):
             interval_counter += 1
 
             job_result.full_details()
-            if job_result.status not in active_job_statuses:
+            if str(job_result.status) not in active_job_statuses:
                 return job_obj
 
         raise ValueError("Did not receieve completed job result for job.")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #309

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
This PR simply casts `job_result.status` to a string for proper comparison of pre-determined job statuses.

Unfortunately, I am not able to add an integration test to verify this as [was described here](https://github.com/nautobot/pynautobot/pull/216#issuecomment-2233816252). I was able to verify this worked by running the same script described in the related issue and it waited the full amount of time as expected.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))

