### PR TITLE
Fixing parsing lists of choices

### DIFF
--- a/changes/322.fixed
+++ b/changes/322.fixed
@@ -1,0 +1,1 @@
+Fixed parsing choices for fields that are a list of choices.

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -509,7 +509,12 @@ class Endpoint:
         elif req.get("actions", {}).get("POST") is not None:
             # Nautobot 2.4+
             post_data = req["actions"]["POST"]
-            self._choices = {prop: post_data[prop]["choices"] for prop in post_data if "choices" in post_data[prop]}
+            self._choices = {}
+            for prop in post_data:
+                if "choices" in post_data[prop]:
+                    self._choices[prop] = post_data[prop]["choices"]
+                elif post_data[prop]["type"] == "list" and "choices" in post_data[prop].get("child", {}):
+                    self._choices[prop] = post_data[prop]["child"]["choices"]
         else:
             raise ValueError(f"Unexpected format in the OPTIONS response at {self.url}")
         return self._choices

--- a/tests/integration/test_endpoint.py
+++ b/tests/integration/test_endpoint.py
@@ -1,5 +1,8 @@
 """Endpoint tests."""
 
+import pytest
+from packaging import version
+
 
 class TestEndpoint:
     """Verify different methods on an endpoint."""
@@ -21,6 +24,16 @@ class TestEndpoint:
         # Not testing that we get specific choices back, just in case of changes in the API
         assert isinstance(choices, dict)
         assert len(choices) > 0
+
+    def test_child_choices(self, nb_client, nb_status):
+        nautobot_version = nb_status["nautobot-version"]
+        if version.parse(nautobot_version) < version.parse("2.4"):
+            pytest.skip("Child choices are only in Nautobot 2.4+")
+
+        # Some endpoints have fields that is a list of choices (Issue 322)
+        choices = nb_client.dcim.controllers.choices()
+        assert isinstance(choices, dict)
+        assert "capabilities" in choices
 
 
 class TestPagination:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #322

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
In Nautobot 2.4, some of the newer choice fields let you select multiple choices. The way we currently parse choices in the `Endpoint.choices()` method was limited to only looking for single option choices. This PR fixes the parsing to also include list fields.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests