### PR TITLE
Prep for release v2.6.5

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -5,6 +5,12 @@ Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Se
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## [v2.6.5](https://github.com/nautobot/pynautobot/releases/tag/v2.6.5)
+
+### Fixed
+
+- [#322](https://github.com/nautobot/pynautobot/issues/322) - Fixed the serialization of model fields that are lists of choices to return just the values.
+
 ## [v2.6.4](https://github.com/nautobot/pynautobot/releases/tag/v2.6.4)
 
 ### Added

--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -50,7 +50,6 @@ def get_return(lookup, return_fields=None):
             return lookup[i]
         if hasattr(lookup, i):
             # check if this is a "choices" field record
-            # from a Nautobot 2.7 server.
             if sorted(dict(lookup)) == sorted(["id", "value", "label"]):
                 return getattr(lookup, "value")
             return getattr(lookup, i)
@@ -255,7 +254,7 @@ class Record:
         """
 
         def list_parser(list_item):
-            if isinstance(list_item, dict) and list_item.get("id"):
+            if isinstance(list_item, dict):
                 return self.default_ret(list_item, self.api, self.endpoint)
             return list_item
 
@@ -355,7 +354,8 @@ class Record:
                     current_val = getattr(current_val, "serialize")(nested=True)
 
                 if isinstance(current_val, list):
-                    current_val = [v.id if isinstance(v, Record) else v for v in current_val]
+                    # If the list contains a Record, get the id of a related object or the value of a choice field
+                    current_val = [get_return(v) if isinstance(v, Record) else v for v in current_val]
                     if i in LIST_AS_SET and (
                         all(isinstance(v, str) for v in current_val) or all(isinstance(v, int) for v in current_val)
                     ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [tool.poetry]
 name = "pynautobot"
-version = "2.6.4"
+version = "2.6.5"
 description = "Nautobot API client library"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"

--- a/tests/integration/test_response.py
+++ b/tests/integration/test_response.py
@@ -1,0 +1,32 @@
+"""Response tests."""
+
+import pytest
+from packaging import version
+
+
+class TestRecord:
+    """Test the Record class."""
+
+    def test_serialize_single_choice(self, nb_client):
+        devices = nb_client.dcim.devices.all()
+        device = devices[0]
+        assert isinstance(dict(device)["face"], dict)
+        face_value = dict(device)["face"]["value"]
+        assert isinstance(device.serialize()["face"], str)
+        assert device.serialize()["face"] == face_value
+
+    def test_serialize_choice_list(self, nb_client, nb_status):
+        nautobot_version = nb_status["nautobot-version"]
+        if version.parse(nautobot_version) < version.parse("2.4"):
+            pytest.skip("Wireless models are only in Nautobot 2.4+")
+
+        radio_profile = nb_client.wireless.radio_profiles.create(
+            name="Test Radio Profile",
+            regulatory_domain="US",
+            channel_width=[20, 40],
+        )
+
+        assert isinstance(dict(radio_profile)["channel_width"][0], dict)
+        channel_width_value = dict(radio_profile)["channel_width"][0]["value"]
+        assert isinstance(radio_profile.serialize()["channel_width"][0], int)
+        assert radio_profile.serialize()["channel_width"][0] == channel_width_value


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #322

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

This PR changes how we deal with lists of dicts on objects. Typically a dict is treated like a related object in pynautobot and we create a corresponding Record object. In the case of choices, we also create a Record object, but these objects don't have an ID but a value instead. The serialize method was designed to return the most basic representation of each of these Record objects (e.g., id or value).

This PR extends this functionality to account for lists of dicts to all be lists of Records and then return the id or value of each of those Record objects.

<details>
    <summary>Before fix</summary>

```python
In [1]: from pynautobot import api

In [2]: nb = api(url="https://demo.nautobot.com/", token=40*"a")

In [3]: device = nb.dcim.devices.get(name="ams01-asw-01")

In [4]: type(device.face)
Out[4]: pynautobot.core.response.Record

In [5]: device.serialize()["face"]
Out[5]: 'front'

In [6]: radio = nb.wireless.radio_profiles.get(name="802.11ac")

In [7]: type(radio.channel_width)
Out[7]: list

In [8]: type(radio.channel_width[0])
Out[8]: dict

In [9]: radio.serialize()["channel_width"]
Out[9]:
[{'value': 20, 'label': '20 MHz'},
 {'value': 40, 'label': '40 MHz'},
 {'value': 80, 'label': '80 MHz'},
 {'value': 160, 'label': '160 MHz'}]
```

</details>

<details>
    <summary>After fix</summary>

```python
In [1]: from pynautobot import api

In [2]: nb = api(url="https://demo.nautobot.com/", token=40*"a")

In [3]: device = nb.dcim.devices.get(name="ams01-asw-01")

In [4]: type(device.face)
Out[4]: pynautobot.core.response.Record

In [5]: device.serialize()["face"]
Out[5]: 'front'

In [6]: radio = nb.wireless.radio_profiles.get(name="802.11ac")

In [7]: type(radio.channel_width)
Out[7]: list

In [8]: type(radio.channel_width[0])
Out[8]: pynautobot.core.response.Record

In [9]: radio.serialize()["channel_width"]
Out[9]: [20, 40, 80, 160]
```

</details>

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
