### PR TITLE
Removing the version validation from API init

### DIFF
--- a/changes/202.removed
+++ b/changes/202.removed
@@ -1,0 +1,1 @@
+Removed the Nautobot version 2 validation check from the API instantiation.

--- a/pynautobot/core/api.py
+++ b/pynautobot/core/api.py
@@ -17,7 +17,6 @@
 # This file has been modified by NetworktoCode, LLC.
 
 import requests
-from packaging import version
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
@@ -119,13 +118,6 @@ class Api:
         self.data_validation = App(self, "data-validation")
         self.plugins = PluginsApp(self)
         self.graphql = GraphQLQuery(self)
-        self._validate_version()
-
-    def _validate_version(self):
-        """Validate API version if eq or ge than 2.0 raise an error."""
-        api_version = self.version
-        if api_version.replace(".", "").isnumeric() and version.parse(api_version) < version.parse("2.0"):
-            raise ValueError("Nautobot version 1 detected, please downgrade pynautobot to version 1.x")
 
     @property
     def version(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -69,17 +69,6 @@ class ApiVersionTestCase(unittest.TestCase):
         headers = {"API-Version": "1.999"}
         ok = True
 
-    @patch(
-        "requests.sessions.Session.get",
-        return_value=ResponseHeadersWithVersion(),
-    )
-    def test_api_version(self, *_):
-        with self.assertRaises(ValueError) as error:
-            pynautobot.api(HOST)
-        self.assertEqual(
-            str(error.exception), "Nautobot version 1 detected, please downgrade pynautobot to version 1.x"
-        )
-
     class ResponseHeadersWithoutVersion:  # pylint: disable=too-few-public-methods
         """Response headers without version."""
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #202

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
This PR removes the version validation when you initialize a `pynautobot.api` object. Pynautobot should be compatible with both Nautobot v2 and v3 in its current state, so as we drop Nautobot v1.6 support we can remove this validation.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
