### PR TITLE
Adding `exclude_m2m` and `include_default` options

### DIFF
--- a/changes/343.added
+++ b/changes/343.added
@@ -1,0 +1,1 @@
+Added `exclude_m2m` parameter to `api` constructor to allow for automatic exclusion/inclusion of many-to-many relationships for get/filter/all requests.

--- a/changes/70.added
+++ b/changes/70.added
@@ -1,0 +1,1 @@
+Added the ability to include additional fields by default in all retrieve operations (e.g., `all()`, `filter()`, `get()`) by setting the `include_default` parameter when instantiating the `Api` object.

--- a/docs/user/basic/examples.md
+++ b/docs/user/basic/examples.md
@@ -153,6 +153,39 @@ This page provides for examples of how to use pynautobot from the community. Wha
         'aaa-new-model': False}
         ```
 
+=== "Including Additional Fields"
+
+    When you instantiate the `Api` object, you can set `include_default` to a comma-separated list of fields that you want to include by default in all retrieve operations (e.g., `all()`, `filter()`, `get()`). This allows you to automatically include fields that are not included in the default response.
+
+    Examples include:
+
+    - Config Context
+    - Computed Fields
+    - Relationships
+
+    ```python
+    import pynautobot
+
+    nautobot = pynautobot.api(url="https://demo.nautobot.com/", token=40*"a", include_default="config_context,computed_fields")
+    ```
+
+    You can also use the `include` parameter in individual `all()`, `filter()`, or `get()` method calls to override the default setting.
+
+    ```python
+    import pynautobot
+
+    nautobot = pynautobot.api(url="https://demo.nautobot.com/", token=40*"a")
+
+    # Retrieve all devices with config context and computed fields included
+    devices = nautobot.dcim.devices.all(include="config_context,computed_fields")
+
+    # Retrieve a single device with computed fields included
+    device = nautobot.dcim.devices.get(name="sample-rtr-01", include="computed_fields")
+
+    # Retrieve devices with relationships included
+    devices = nautobot.dcim.devices.filter(include="relationships")
+    ```
+
 === "Including/Excluding Many-to-Many Fields"
 
     When you instantiate the `Api` object, you can set `exclude_m2m` to either True or False to automatically include the parameter for all subsequent retrieve operations (e.g., `all()`, `filter()`, `get()`).

--- a/docs/user/basic/examples.md
+++ b/docs/user/basic/examples.md
@@ -152,3 +152,29 @@ This page provides for examples of how to use pynautobot from the community. Wha
         {'name': 'secure', 'role': 'RW'}]},
         'aaa-new-model': False}
         ```
+
+=== "Including/Excluding Many-to-Many Fields"
+
+    When you instantiate the `Api` object, you can set `exclude_m2m` to either True or False to automatically include the parameter for all subsequent retrieve operations (e.g., `all()`, `filter()`, `get()`).
+
+    ```python
+    import pynautobot
+
+    nautobot = pynautobot.api(url="https://demo.nautobot.com/", token=40*"a", exclude_m2m=False)
+
+    ```
+
+    You can also include the `exclude_m2m` parameter in individual `all()`, `filter()`, or `get()` method calls to override the default setting.
+
+    ```python
+    import pynautobot
+
+    nautobot = pynautobot.api(url="https://demo.nautobot.com/", token=40*"a", exclude_m2m=True)
+    
+    # Retrieve all devices with many-to-many fields included
+    devices = nautobot.dcim.devices.all(exclude_m2m=False)
+
+    # Retrieve a single device with many-to-many fields included
+    device = nautobot.dcim.devices.get(name="sample-rtr-01", exclude_m2m=False)
+
+    ```

--- a/pynautobot/core/api.py
+++ b/pynautobot/core/api.py
@@ -44,6 +44,10 @@ class Api:
         verify (bool, optional): Whether to verify SSL certificates. Defaults to `True`.
         exclude_m2m (bool, optional): (Nautobot 2.4+) Whether to exclude/include
             many-to-many relationships for get/filter/all requests. Defaults to `None`.
+        include_default (str, optional): A comma-separated list of items to include
+            by default for get/filter/all requests. Defaults to `None`.
+            For example, `include_default="config_context,computed_fields"` will include
+            the `config_context` and `computed_fields` for all get/filter/all responses.
 
     Attributes:
         dcim: An instance of the `App` class providing access to DCIM endpoints.
@@ -83,6 +87,7 @@ class Api:
         retries=0,
         verify=True,
         exclude_m2m=None,
+        include_default=None,
     ):
         """Initialize the Api object."""
         from pynautobot import __version__  # pylint: disable=import-outside-toplevel
@@ -111,6 +116,8 @@ class Api:
         self.default_filters = {}
         if exclude_m2m is not None:
             self.default_filters["exclude_m2m"] = exclude_m2m
+        if include_default is not None:
+            self.default_filters["include"] = include_default
 
         self.dcim = App(self, "dcim")
         self.ipam = App(self, "ipam")

--- a/pynautobot/core/api.py
+++ b/pynautobot/core/api.py
@@ -42,6 +42,8 @@ class Api:
         retries (int, optional): The number of retries for HTTP status codes
             429, 500, 502, 503, and 504. Defaults to 0 (no retries).
         verify (bool, optional): Whether to verify SSL certificates. Defaults to `True`.
+        exclude_m2m (bool, optional): (Nautobot 2.4+) Whether to exclude/include
+            many-to-many relationships for get/filter/all requests. Defaults to `None`.
 
     Attributes:
         dcim: An instance of the `App` class providing access to DCIM endpoints.
@@ -80,6 +82,7 @@ class Api:
         api_version=None,
         retries=0,
         verify=True,
+        exclude_m2m=None,
     ):
         """Initialize the Api object."""
         from pynautobot import __version__  # pylint: disable=import-outside-toplevel
@@ -105,6 +108,9 @@ class Api:
         self.threading = threading
         self.max_workers = max_workers
         self.api_version = api_version
+        self.default_filters = {}
+        if exclude_m2m is not None:
+            self.default_filters["exclude_m2m"] = exclude_m2m
 
         self.dcim = App(self, "dcim")
         self.ipam = App(self, "ipam")

--- a/pynautobot/core/response.py
+++ b/pynautobot/core/response.py
@@ -316,6 +316,7 @@ class Record:
                 token=self.api.token,
                 http_session=self.api.http_session,
                 api_version=self.api.api_version,
+                filters=self.api.default_filters,
             )
             self._parse_values(req.get())
             self.has_details = True
@@ -431,6 +432,7 @@ class Record:
                     token=self.api.token,
                     http_session=self.api.http_session,
                     api_version=self.api.api_version,
+                    filters=self.api.default_filters,
                 )
                 if req.patch({i: serialized[i] for i in diff}):
                     return True

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,7 @@ import tempfile
 import pytest
 import requests
 import yaml
+from packaging import version
 
 import pynautobot
 
@@ -158,7 +159,19 @@ def nb_client(devicetype_library_repo_dirpath):
     """Setup the nb_client and import necessary data."""
 
     nb_api = pynautobot.api(_NAUTOBOT_URL, token="0123456789abcdef0123456789abcdef01234567")
+    nb_status = nb_api.status()
+    if version.parse(nb_status.get("nautobot-version")) >= version.parse("2.4"):
+        nb_api.default_filters["exclude_m2m"] = False
+
     populate_nautobot_object_types(nb_api=nb_api, devicetype_library_repo_dirpath=devicetype_library_repo_dirpath)
+
+    return nb_api
+
+
+@pytest.fixture(scope="session")
+def nb_client_exclude_m2m():
+    """Setup the nb_client and import necessary data."""
+    nb_api = pynautobot.api(_NAUTOBOT_URL, token="0123456789abcdef0123456789abcdef01234567", exclude_m2m=True)
 
     return nb_api
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -177,6 +177,16 @@ def nb_client_exclude_m2m():
 
 
 @pytest.fixture(scope="session")
+def nb_client_include_config_context():
+    """Create a nb_client with the include_default filter set to config_context."""
+    nb_api = pynautobot.api(
+        _NAUTOBOT_URL, token="0123456789abcdef0123456789abcdef01234567", include_default="config_context"
+    )
+
+    return nb_api
+
+
+@pytest.fixture(scope="session")
 def nb_status(nb_client):
     """Cache the status of the Nautobot instance as fixture so we don't have to call it repeatedly."""
     status = nb_client.status()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -170,7 +170,7 @@ def nb_client(devicetype_library_repo_dirpath):
 
 @pytest.fixture(scope="session")
 def nb_client_exclude_m2m():
-    """Setup the nb_client and import necessary data."""
+    """Create a nb_client with the exclude_m2m filter set to True."""
     nb_api = pynautobot.api(_NAUTOBOT_URL, token="0123456789abcdef0123456789abcdef01234567", exclude_m2m=True)
 
     return nb_api

--- a/tests/integration/test_default_filters.py
+++ b/tests/integration/test_default_filters.py
@@ -67,3 +67,60 @@ class TestExcludeM2M:
         """Test that even if exclude_m2m is set, we can override it for a single filter request."""
         prefixes = nb_client.ipam.prefixes.filter(prefix="192.0.0.0/8", exclude_m2m=True)
         assert "locations" not in prefixes[0].serialize()
+
+
+class TestIncludeFilters:
+    """Testing include filters."""
+
+    def test_device_exclude_config_context_get(self, nb_client):
+        devices = nb_client.dcim.devices.get(name="dev-1")
+        assert "config_context" not in devices.serialize()
+
+    def test_device_exclude_config_context_all(self, nb_client):
+        devices = nb_client.dcim.devices.all()
+        assert "config_context" not in devices[0].serialize()
+
+    def test_device_exclude_config_context_filter(self, nb_client):
+        devices = nb_client.dcim.devices.filter(name="dev-1")
+        assert "config_context" not in devices[0].serialize()
+
+    def test_device_include_config_context_get(self, nb_client_include_config_context):
+        devices = nb_client_include_config_context.dcim.devices.get(name="dev-1")
+        assert "config_context" in devices.serialize()
+
+    def test_device_include_config_context_all(self, nb_client_include_config_context):
+        nb_client_include_config_context.default_filters["include"] = "config_context,computed_fields"
+        devices = nb_client_include_config_context.dcim.devices.all()
+        assert "config_context" in devices[0].serialize()
+        assert "computed_fields" in devices[0].serialize()
+
+    def test_device_include_config_context_filter(self, nb_client_include_config_context):
+        devices = nb_client_include_config_context.dcim.devices.filter(name="dev-1")
+        assert "config_context" in devices[0].serialize()
+
+    def test_device_include_config_context_override_false_get(self, nb_client_include_config_context):
+        devices = nb_client_include_config_context.dcim.devices.get(name="dev-1", include="")
+        assert "config_context" not in devices.serialize()
+
+    def test_device_include_config_context_override_false_all(self, nb_client_include_config_context):
+        nb_client_include_config_context.default_filters["include"] = "config_context,computed_fields"
+        devices = nb_client_include_config_context.dcim.devices.all(include="")
+        assert "config_context" not in devices[0].serialize()
+        assert "computed_fields" not in devices[0].serialize()
+
+    def test_device_include_config_context_override_false_filter(self, nb_client_include_config_context):
+        devices = nb_client_include_config_context.dcim.devices.filter(name="dev-1", include="")
+        assert "config_context" not in devices[0].serialize()
+
+    def test_device_include_config_context_override_true_get(self, nb_client):
+        devices = nb_client.dcim.devices.get(name="dev-1", include="config_context")
+        assert "config_context" in devices.serialize()
+
+    def test_device_include_config_context_override_true_all(self, nb_client):
+        devices = nb_client.dcim.devices.all(include="config_context,computed_fields")
+        assert "config_context" in devices[0].serialize()
+        assert "computed_fields" in devices[0].serialize()
+
+    def test_device_include_config_context_override_true_filter(self, nb_client):
+        devices = nb_client.dcim.devices.filter(name="dev-1", include="config_context")
+        assert "config_context" in devices[0].serialize()

--- a/tests/integration/test_exclude_m2m.py
+++ b/tests/integration/test_exclude_m2m.py
@@ -1,0 +1,69 @@
+"""Exclude m2m tests."""
+
+import pytest
+from packaging import version
+
+
+class TestExcludeM2M:
+    """Testing exclude_m2m."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def skipif_version(self, nb_status):
+        """Skip all tests in this class if the Nautobot version is less than 2.4."""
+        nautobot_version = nb_status.get("nautobot-version")
+        if version.parse(nautobot_version) < version.parse("2.4"):
+            pytest.skip("The exclude_m2m filter is only in Nautobot 2.4+")
+
+    def test_prefix_include_m2m_get(self, nb_client):
+        prefixes = nb_client.ipam.prefixes.get(prefix="192.0.0.0/8")
+        assert "locations" in prefixes.serialize()
+
+    def test_prefix_include_m2m_all(self, nb_client):
+        prefixes = nb_client.ipam.prefixes.all()
+        assert "locations" in prefixes[0].serialize()
+
+    def test_prefix_include_m2m_filter(self, nb_client):
+        prefixes = nb_client.ipam.prefixes.filter(prefix="192.0.0.0/8")
+        assert "locations" in prefixes[0].serialize()
+
+    def test_prefix_exclude_m2m_get(self, nb_client_exclude_m2m):
+        prefixes = nb_client_exclude_m2m.ipam.prefixes.get(prefix="192.0.0.0/8")
+        assert "locations" not in prefixes.serialize()
+
+    def test_prefix_exclude_m2m_all(self, nb_client_exclude_m2m):
+        prefixes = nb_client_exclude_m2m.ipam.prefixes.all()
+        assert "locations" not in prefixes[0].serialize()
+
+    def test_prefix_exclude_m2m_filter(self, nb_client_exclude_m2m):
+        prefixes = nb_client_exclude_m2m.ipam.prefixes.filter(prefix="192.0.0.0/8")
+        assert "locations" not in prefixes[0].serialize()
+
+    def test_prefix_m2m_override_false_get(self, nb_client_exclude_m2m):
+        """Test that even if exclude_m2m is set, we can override it for a single get request."""
+        prefixes = nb_client_exclude_m2m.ipam.prefixes.get(prefix="192.0.0.0/8", exclude_m2m=False)
+        assert "locations" in prefixes.serialize()
+
+    def test_prefix_m2m_override_false_all(self, nb_client_exclude_m2m):
+        """Test that even if exclude_m2m is set, we can override it for a single all request."""
+        prefixes = nb_client_exclude_m2m.ipam.prefixes.all(exclude_m2m=False)
+        assert "locations" in prefixes[0].serialize()
+
+    def test_prefix_m2m_override_false_filter(self, nb_client_exclude_m2m):
+        """Test that even if exclude_m2m is set, we can override it for a single filter request."""
+        prefixes = nb_client_exclude_m2m.ipam.prefixes.filter(prefix="192.0.0.0/8", exclude_m2m=False)
+        assert "locations" in prefixes[0].serialize()
+
+    def test_prefix_m2m_override_true_get(self, nb_client):
+        """Test that even if exclude_m2m is set, we can override it for a single get request."""
+        prefixes = nb_client.ipam.prefixes.get(prefix="192.0.0.0/8", exclude_m2m=True)
+        assert "locations" not in prefixes.serialize()
+
+    def test_prefix_m2m_override_true_all(self, nb_client):
+        """Test that even if exclude_m2m is set, we can override it for a single all request."""
+        prefixes = nb_client.ipam.prefixes.all(exclude_m2m=True)
+        assert "locations" not in prefixes[0].serialize()
+
+    def test_prefix_m2m_override_true_filter(self, nb_client):
+        """Test that even if exclude_m2m is set, we can override it for a single filter request."""
+        prefixes = nb_client.ipam.prefixes.filter(prefix="192.0.0.0/8", exclude_m2m=True)
+        assert "locations" not in prefixes[0].serialize()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -87,6 +87,25 @@ class AppConfigTestCase(unittest.TestCase):
         )
 
 
+class AppExcludeM2MTestCase(unittest.TestCase):
+    """App exclude m2m test."""
+
+    @patch("pynautobot.api.version", "2.4")
+    def test_exclude_m2m_true(self, *_):
+        api = pynautobot.api(HOST, **def_kwargs, exclude_m2m=True)
+        self.assertEqual(api.default_filters["exclude_m2m"], True)
+
+    @patch("pynautobot.api.version", "2.4")
+    def test_exclude_m2m_false(self, *_):
+        api = pynautobot.api(HOST, **def_kwargs, exclude_m2m=False)
+        self.assertEqual(api.default_filters["exclude_m2m"], False)
+
+    @patch("pynautobot.api.version", "2.4")
+    def test_exclude_m2m_none(self, *_):
+        api = pynautobot.api(HOST, **def_kwargs)
+        self.assertNotIn("exclude_m2m", api.default_filters.keys())
+
+
 class PluginAppCustomChoicesTestCase(unittest.TestCase):
     """Plugin app custom choices test."""
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -106,6 +106,25 @@ class AppExcludeM2MTestCase(unittest.TestCase):
         self.assertNotIn("exclude_m2m", api.default_filters.keys())
 
 
+class AppIncludeFiltersTestCase(unittest.TestCase):
+    """App include filters test."""
+
+    @patch("pynautobot.api.version", "2.0")
+    def test_include_none(self, *_):
+        api = pynautobot.api(HOST, **def_kwargs)
+        self.assertNotIn("include", api.default_filters.keys())
+
+    @patch("pynautobot.api.version", "2.0")
+    def test_include_config_context(self, *_):
+        api = pynautobot.api(HOST, **def_kwargs, include_default="config_context")
+        self.assertEqual(api.default_filters["include"], "config_context")
+
+    @patch("pynautobot.api.version", "2.0")
+    def test_include_multiple(self, *_):
+        api = pynautobot.api(HOST, **def_kwargs, include_default="config_context,computed_fields")
+        self.assertEqual(api.default_filters["include"], "config_context,computed_fields")
+
+
 class PluginAppCustomChoicesTestCase(unittest.TestCase):
     """Plugin app custom choices test."""
 

--- a/tests/unit/test_api_version.py
+++ b/tests/unit/test_api_version.py
@@ -11,7 +11,7 @@ class APIVersionTestCase(unittest.TestCase):
     """Test API versioning."""
 
     def setUp(self):
-        self.api = Mock(base_url="http://localhost:8000/api", api_version="1.3", name="API-Mock")
+        self.api = Mock(base_url="http://localhost:8000/api", api_version="1.3", name="API-Mock", default_filters={})
         self.api.token = 1234
         app = Mock(name="test")
         app.name = "test"

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -11,60 +11,45 @@ from pynautobot.core.response import Record
 class EndPointTestCase(unittest.TestCase):
     """Endpoint Test Case"""
 
+    def setUp(self):
+        self.api = Mock(base_url="http://localhost:8000/api", default_filters={})
+        self.app = Mock(name="test")
+        self.test_obj = Endpoint(self.api, self.app, "test")
+
     def test_filter(self):
         with patch("pynautobot.core.query.Request.get", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
             mock.return_value = [{"id": 123}, {"id": 321}]
-            test_obj = Endpoint(api, app, "test")
-            test = test_obj.filter(test="test")
+            test = self.test_obj.filter(test="test")
             self.assertEqual(len(test), 2)
 
     def test_filter_reserved_kwargs(self):
-        api = Mock(base_url="http://localhost:8000/api")
-        app = Mock(name="test")
-        test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as _:
-            test_obj.filter(pk=1)
+            self.test_obj.filter(pk=1)
 
     def test_all_none_limit_offset(self):
         with patch("pynautobot.core.query.Request.get", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
             mock.return_value = [{"id": 123}, {"id": 321}]
-            test_obj = Endpoint(api, app, "test")
             with self.assertRaises(ValueError) as _:
-                test_obj.all(limit=None, offset=1)
+                self.test_obj.all(limit=None, offset=1)
 
     def test_all_equals_filter_empty_kwargs(self):
         with patch("pynautobot.core.query.Request.get", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
             mock.return_value = [{"id": 123}, {"id": 321}]
-            test_obj = Endpoint(api, app, "test")
-            self.assertEqual(test_obj.all(), test_obj.filter())
+            self.assertEqual(self.test_obj.all(), self.test_obj.filter())
 
     def test_all_accepts_kwargs(self):
         with patch("pynautobot.core.endpoint.Endpoint.filter", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
-            test_obj = Endpoint(api, app, "test")
-            test_obj.all(include=["config_context"])
+            self.test_obj.all(include=["config_context"])
             mock.assert_called_with(include=["config_context"])
 
     def test_filter_zero_limit_offset(self):
         with patch("pynautobot.core.query.Request.get", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
             mock.return_value = [{"id": 123}, {"id": 321}]
-            test_obj = Endpoint(api, app, "test")
             with self.assertRaises(ValueError) as _:
-                test_obj.filter(test="test", limit=0, offset=1)
+                self.test_obj.filter(test="test", limit=0, offset=1)
 
     def test_choices(self):
         with patch("pynautobot.core.query.Request.options", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
             mock.return_value = {
                 "schema": {
                     "properties": {
@@ -75,104 +60,76 @@ class EndPointTestCase(unittest.TestCase):
                     }
                 }
             }
-            test_obj = Endpoint(api, app, "test")
-            choices = test_obj.choices()
+            choices = self.test_obj.choices()
             self.assertEqual(choices["letter"][1]["display"], "B")
             self.assertEqual(choices["letter"][1]["value"], 2)
 
     def test_update_with_id_and_data(self):
         with patch("pynautobot.core.query.Request._make_call", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
-            test_obj = Endpoint(api, app, "test")
             mock.return_value = [{"name": "test"}]
-            test = test_obj.update(id="db8770c4-61e5-4999-8372-e7fa576a4f65", data={"name": "test"})
+            test = self.test_obj.update(id="db8770c4-61e5-4999-8372-e7fa576a4f65", data={"name": "test"})
             mock.assert_called_with(verb="patch", data={"name": "test"})
             self.assertTrue(test)
 
     def test_update_with_id_and_data_args(self):
         with patch("pynautobot.core.query.Request._make_call", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
-            test_obj = Endpoint(api, app, "test")
             mock.return_value = [{"name": "test"}]
-            test = test_obj.update("db8770c4-61e5-4999-8372-e7fa576a4f65", {"name": "test"})
+            test = self.test_obj.update("db8770c4-61e5-4999-8372-e7fa576a4f65", {"name": "test"})
             mock.assert_called_with(verb="patch", data={"name": "test"})
             self.assertTrue(test)
 
     def test_update_with_id_and_data_args_kwargs(self):
         with patch("pynautobot.core.query.Request._make_call", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
-            test_obj = Endpoint(api, app, "test")
             mock.return_value = [{"name": "test"}]
-            test = test_obj.update("db8770c4-61e5-4999-8372-e7fa576a4f65", data={"name": "test"})
+            test = self.test_obj.update("db8770c4-61e5-4999-8372-e7fa576a4f65", data={"name": "test"})
             mock.assert_called_with(verb="patch", data={"name": "test"})
             self.assertTrue(test)
 
     def test_update_with_dict(self):
         with patch("pynautobot.core.query.Request._make_call", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
-            test_obj = Endpoint(api, app, "test")
             mock.return_value = [{"id": "db8770c4-61e5-4999-8372-e7fa576a4f65", "name": "test"}]
-            test = test_obj.update([{"id": "db8770c4-61e5-4999-8372-e7fa576a4f65", "name": "test"}])
+            test = self.test_obj.update([{"id": "db8770c4-61e5-4999-8372-e7fa576a4f65", "name": "test"}])
             mock.assert_called_with(verb="patch", data=[{"id": "db8770c4-61e5-4999-8372-e7fa576a4f65", "name": "test"}])
             self.assertTrue(test)
 
     def test_update_with_objects(self):
         with patch("pynautobot.core.query.Request._make_call", return_value=Mock()) as mock:
             ids = ["db8770c4-61e5-4999-8372-e7fa576a4f65", "e9b5f2e0-4f20-41ad-9179-90a4987f743e"]
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
-            test_obj = Endpoint(api, app, "test")
-            objects = [Record({"id": i, "name": "test_" + str(i)}, api, test_obj) for i in ids]
+            objects = [Record({"id": i, "name": "test_" + str(i)}, self.api, self.test_obj) for i in ids]
             for o in objects:
                 o.name = "new_" + str(o.id)
             mock.return_value = [o.serialize() for o in objects]
-            test = test_obj.update(objects)
+            test = self.test_obj.update(objects)
             mock.assert_called_with(verb="patch", data=[{"id": i, "name": "new_" + str(i)} for i in ids])
             self.assertTrue(test)
 
     def test_update_with_invalid_objects_type(self):
         objects = {"id": "db8770c4-61e5-4999-8372-e7fa576a4f65", "name": "test"}
-        api = Mock(base_url="http://localhost:8000/api")
-        app = Mock(name="test")
-        test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as exc:
-            test_obj.update(objects)
+            self.test_obj.update(objects)
         self.assertEqual(
             str(exc.exception), "You must provide either a UUID and data dict or a list of objects to update"
         )
 
     def test_update_with_invalid_type_in_objects(self):
         objects = [[{"id": "db8770c4-61e5-4999-8372-e7fa576a4f65", "name": "test"}]]
-        api = Mock(base_url="http://localhost:8000/api")
-        app = Mock(name="test")
-        test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as exc:
-            test_obj.update(objects)
+            self.test_obj.update(objects)
         self.assertEqual(str(exc.exception.__cause__), "Invalid object type: <class 'list'>")
 
     def test_update_with_missing_id_attribute(self):
-        api = Mock(base_url="http://localhost:8000/api")
-        app = Mock(name="test")
-        test_obj = Endpoint(api, app, "test")
         objects = [
-            Record({"no_id": "db8770c4-61e5-4999-8372-e7fa576a4f65", "name": "test"}, api, test_obj),
+            Record({"no_id": "db8770c4-61e5-4999-8372-e7fa576a4f65", "name": "test"}, self.api, self.test_obj),
         ]
         with self.assertRaises(ValueError) as exc:
-            test_obj.update(objects)
+            self.test_obj.update(objects)
         self.assertEqual(str(exc.exception.__cause__), "'Record' object has no attribute 'id'")
 
     def test_delete_with_ids(self):
         with patch("pynautobot.core.query.Request._make_call", return_value=Mock()) as mock:
             ids = ["db8770c4-61e5-4999-8372-e7fa576a4f65", "e9b5f2e0-4f20-41ad-9179-90a4987f743e"]
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
-            test_obj = Endpoint(api, app, "test")
-            test = test_obj.delete(ids)
+            test = self.test_obj.delete(ids)
             mock.assert_called_with(verb="delete", data=[{"id": i} for i in ids])
             self.assertTrue(test)
 
@@ -180,41 +137,29 @@ class EndPointTestCase(unittest.TestCase):
         with patch("pynautobot.core.query.Request._make_call", return_value=Mock()) as mock:
             ids = ["db8770c4-61e5-4999-8372-e7fa576a4f65", "e9b5f2e0-4f20-41ad-9179-90a4987f743e"]
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api")
-            app = Mock(name="test")
-            test_obj = Endpoint(api, app, "test")
-            objects = [Record({"id": i, "name": "test_" + str(i)}, api, test_obj) for i in ids]
-            test = test_obj.delete(objects)
+            objects = [Record({"id": i, "name": "test_" + str(i)}, self.api, self.test_obj) for i in ids]
+            test = self.test_obj.delete(objects)
             mock.assert_called_with(verb="delete", data=[{"id": i} for i in ids])
             self.assertTrue(test)
 
     def test_delete_with_invalid_uuid(self):
         ids = ["123", "456"]
-        api = Mock(base_url="http://localhost:8000/api")
-        app = Mock(name="test")
-        test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as exc:
-            test_obj.delete(ids)
+            self.test_obj.delete(ids)
         self.assertEqual(str(exc.exception.__cause__), "badly formed hexadecimal UUID string")
 
     def test_delete_with_invalid_id_type(self):
         ids = [123, 456]
-        api = Mock(base_url="http://localhost:8000/api")
-        app = Mock(name="test")
-        test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as exc:
-            test_obj.delete(ids)
+            self.test_obj.delete(ids)
         self.assertEqual(str(exc.exception.__cause__), "Invalid object type: <class 'int'>")
 
     def test_delete_with_invalid_object(self):
-        api = Mock(base_url="http://localhost:8000/api")
-        app = Mock(name="test")
-        test_obj = Endpoint(api, app, "test")
         objects = [
-            Record({"no_id": "db8770c4-61e5-4999-8372-e7fa576a4f65", "name": "test"}, api, test_obj),
+            Record({"no_id": "db8770c4-61e5-4999-8372-e7fa576a4f65", "name": "test"}, self.api, self.test_obj),
         ]
         with self.assertRaises(ValueError) as exc:
-            test_obj.delete(objects)
+            self.test_obj.delete(objects)
         self.assertEqual(str(exc.exception.__cause__), "'Record' object has no attribute 'id'")
 
 

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -242,6 +242,7 @@ class RecordTestCase(unittest.TestCase):
         app = Mock()
         app.token = "abc123"
         app.base_url = "http://localhost:8080/api"
+        app.default_filters = {}
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         endpoint.return_obj = Record
@@ -269,6 +270,7 @@ class RecordTestCase(unittest.TestCase):
         app = Mock()
         app.token = "abc123"
         app.base_url = "http://localhost:8080/testing/api"
+        app.default_filters = {}
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         endpoint.return_obj = Record


### PR DESCRIPTION
Closes: #343 

In Nautobot v3, we are investigating the possibility of [inverting the default inclusion](https://github.com/nautobot/nautobot/issues/7456) of many-to-many fields in REST API responses in order to improve performance. This PR aims to make that transition easier for users with workflows that currently use and expect those M2M fields to be in the response. This PR adds the `exclude_m2m` option to the Api class constructor so that it can be toggled by default for all retrieval operations (`get`, `filter`, `all`) instead of needing to add the query param to individual calls.

Closes: #70 

In the same vein as `exclude_m2m`, this PR also adds the `include_default` option to the Api class in order to allow the default inclusion of fields that are [not included by default](https://docs.nautobot.com/projects/core/en/stable/user-guide/platform-functionality/rest-api/filtering/#filtering-included-fields).
