### PR TITLE
Prep for release v2.7.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # Default owner(s) of all files in this repository
-
-- @jmcgill298 @jvanderaa @joewesch @matt852 @PhillSimonds @boabdilperez @susanhooks
+* @jvanderaa @jmcgill298 @joewesch @nautobot/maintain-nautobot-apps

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -5,6 +5,12 @@ Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Se
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## [v2.7.1](https://github.com/nautobot/pynautobot/releases/tag/v2.7.1)
+
+### Added
+
+- [#348](https://github.com/nautobot/pynautobot/issues/348) - Added sending the default filter params to create and update endpoints so that the returned objects include any applicable requested fields.
+
 ## [v2.7.0](https://github.com/nautobot/pynautobot/releases/tag/v2.7.0)
 
 ### Added

--- a/pynautobot/core/app.py
+++ b/pynautobot/core/app.py
@@ -98,8 +98,12 @@ class App:
 
         return self._choices
 
-    def get_custom_fields(self):
+    def get_custom_fields(self, filters=None):
         """Returns custom-fields response from app.
+
+        Args:
+            filters (dict, optional): Contains key/value pairs that
+                correlate to the filters a given endpoint accepts.
 
         Returns:
             (List[Response]): Raw response from Nautobot's custom-fields endpoint.
@@ -133,14 +137,21 @@ class App:
                 },
             ]
         """
+        filters = self.api.default_filters.copy()
+        filters.update(filters)
         return Request(
             base=f"{self.api.base_url}/{self.name}/custom-fields/",
             token=self.api.token,
             http_session=self.api.http_session,
+            filters=filters,
         ).get()
 
-    def get_custom_field_choices(self):
+    def get_custom_field_choices(self, filters=None):
         """Returns custom-field-choices response from app.
+
+        Args:
+            filters (dict, optional): Contains key/value pairs that
+                correlate to the filters a given endpoint accepts.
 
         Returns:
             (List[Response]): Raw response from Nautobot's custom-field-choices endpoint.
@@ -168,10 +179,13 @@ class App:
                 },
             ]
         """
+        filters = self.api.default_filters.copy()
+        filters.update(filters)
         return Request(
             base=f"{self.api.base_url}/{self.name}/custom-field-choices/",
             token=self.api.token,
             http_session=self.api.http_session,
+            filters=filters,
         ).get()
 
     def config(self):

--- a/pynautobot/core/endpoint.py
+++ b/pynautobot/core/endpoint.py
@@ -287,6 +287,7 @@ class Endpoint:
             token=self.token,
             http_session=self.api.http_session,
             api_version=api_version,
+            filters=self.api.default_filters,
         ).post(args[0] if args else kwargs)
 
         return response_loader(req, self.return_obj, self)
@@ -400,6 +401,7 @@ class Endpoint:
             token=self.api.token,
             http_session=self.api.http_session,
             api_version=self.api.api_version,
+            filters=self.api.default_filters,
         ).patch(bulk_data)
         return response_loader(req, self.return_obj, self)
 
@@ -602,7 +604,11 @@ class DetailEndpoint:
         """
         api_version = api_version or self.parent_obj.api.api_version
 
-        req = Request(api_version=api_version, **self.request_kwargs).get(add_params=kwargs)
+        req = Request(
+            api_version=api_version,
+            filters=self.parent_obj.api.default_filters,
+            **self.request_kwargs,
+        ).get(add_params=kwargs)
 
         if self.custom_return:
             return response_loader(req, self.custom_return, self.parent_obj.endpoint)
@@ -628,7 +634,11 @@ class DetailEndpoint:
         data = data or {}
         api_version = api_version or self.parent_obj.api.api_version
 
-        req = Request(api_version=api_version, **self.request_kwargs).post(data)
+        req = Request(
+            api_version=api_version,
+            filters=self.parent_obj.api.default_filters,
+            **self.request_kwargs,
+        ).post(data)
         if self.custom_return:
             return response_loader(req, self.custom_return, self.parent_obj.endpoint)
         return req
@@ -685,6 +695,7 @@ class JobsEndpoint(Endpoint):
             base=job_run_url,
             token=self.token,
             http_session=self.api.http_session,
+            filters=self.api.default_filters,
             api_version=api_version,
         ).post(args[0] if args else kwargs)
 

--- a/pynautobot/models/dcim.py
+++ b/pynautobot/models/dcim.py
@@ -43,6 +43,7 @@ class TraceableRecord(Record):
             key=str(self.id) + "/trace",
             base=self.endpoint.url,
             token=self.api.token,
+            filters=self.api.default_filters,
             http_session=self.api.http_session,
         )
         uri_to_obj_class_map = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [tool.poetry]
 name = "pynautobot"
-version = "2.7.0"
+version = "2.7.1"
 description = "Nautobot API client library"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"

--- a/tests/integration/test_default_filters.py
+++ b/tests/integration/test_default_filters.py
@@ -68,6 +68,30 @@ class TestExcludeM2M:
         prefixes = nb_client.ipam.prefixes.filter(prefix="192.0.0.0/8", exclude_m2m=True)
         assert "locations" not in prefixes[0].serialize()
 
+    def test_permission_include_m2m_create(self, nb_client):
+        permissions = nb_client.users.permissions.create(
+            name="Testing Exclude M2M Create 1", actions=["view"], object_types=["dcim.device"]
+        )
+        assert "object_types" in permissions.serialize()
+
+    def test_permission_exclude_m2m_create(self, nb_client_exclude_m2m):
+        permissions = nb_client_exclude_m2m.users.permissions.create(
+            name="Testing Exclude M2M Create 2", actions=["view"], object_types=["dcim.device"]
+        )
+        assert "object_types" not in permissions.serialize()
+
+    def test_permission_include_m2m_bulk_update(self, nb_client):
+        permissions = list(nb_client.users.permissions.filter(name="Testing Exclude M2M Create 1"))
+        permissions[0].description = "Testing Exclude M2M Bulk Update 1"
+        permissions_updated = nb_client.users.permissions.update(permissions)
+        assert "object_types" in permissions_updated[0].serialize()
+
+    def test_permission_exclude_m2m_bulk_update(self, nb_client_exclude_m2m):
+        permissions = list(nb_client_exclude_m2m.users.permissions.filter(name="Testing Exclude M2M Create 2"))
+        permissions[0].description = "Testing Exclude M2M Bulk Update 2"
+        permissions_updated = nb_client_exclude_m2m.users.permissions.update(permissions)
+        assert "object_types" not in permissions_updated[0].serialize()
+
 
 class TestIncludeFilters:
     """Testing include filters."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #348

## What's Changed
This is a fast follow patch release after #345 to include the default filter params to a few more methods. When an object is created or updated in Nautobot, the API response will return the serialized object. If we don't include the `exclude_m2m=True` param, for example, as part of our POST or PATCH call, the API may actually set the M2M field(s) but not return them in the response.

