### PR TITLE
Fix get_custom_fields and get_custom_field_choices ignoring the filters argument

### DIFF
--- a/changes/389.fixed
+++ b/changes/389.fixed
@@ -1,0 +1,1 @@
+Fixed `get_custom_fields()` and `get_custom_field_choices()` ignoring the `filters` argument.

--- a/pynautobot/core/app.py
+++ b/pynautobot/core/app.py
@@ -143,14 +143,14 @@ class App:
             >>> nb.extras.get_custom_fields(filters={"content_types": "dcim.device"})
             [...]
         """
-        request_filters = self.api.default_filters.copy()
+        default_filters = self.api.default_filters.copy()
         if filters:
-            request_filters.update(filters)
+            default_filters.update(filters)
         return Request(
             base=f"{self.api.base_url}/{self.name}/custom-fields/",
             token=self.api.token,
             http_session=self.api.http_session,
-            filters=request_filters,
+            filters=default_filters,
         ).get()
 
     def get_custom_field_choices(self, filters=None):
@@ -192,14 +192,14 @@ class App:
             >>> nb.extras.get_custom_field_choices(filters={"field": "test_custom_field_2"})
             [...]
         """
-        request_filters = self.api.default_filters.copy()
+        default_filters = self.api.default_filters.copy()
         if filters:
-            request_filters.update(filters)
+            default_filters.update(filters)
         return Request(
             base=f"{self.api.base_url}/{self.name}/custom-field-choices/",
             token=self.api.token,
             http_session=self.api.http_session,
-            filters=request_filters,
+            filters=default_filters,
         ).get()
 
     def config(self):

--- a/pynautobot/core/app.py
+++ b/pynautobot/core/app.py
@@ -136,14 +136,21 @@ class App:
                     "notes_url": "http://localhost:8000/api/extras/custom-fields/5b39ba88-e5ab-4be2-89f5-5a016473b53c/notes/",
                 },
             ]
+
+            Scope the results by passing a ``filters`` dict, whose key/value
+            pairs are sent as query parameters to the endpoint:
+
+            >>> nb.extras.get_custom_fields(filters={"content_types": "dcim.device"})
+            [...]
         """
-        filters = self.api.default_filters.copy()
-        filters.update(filters)
+        request_filters = self.api.default_filters.copy()
+        if filters:
+            request_filters.update(filters)
         return Request(
             base=f"{self.api.base_url}/{self.name}/custom-fields/",
             token=self.api.token,
             http_session=self.api.http_session,
-            filters=filters,
+            filters=request_filters,
         ).get()
 
     def get_custom_field_choices(self, filters=None):
@@ -178,14 +185,21 @@ class App:
                     "last_updated": "2023-04-15T18:11:57.163237Z"
                 },
             ]
+
+            Scope the results by passing a ``filters`` dict, whose key/value
+            pairs are sent as query parameters to the endpoint:
+
+            >>> nb.extras.get_custom_field_choices(filters={"field": "test_custom_field_2"})
+            [...]
         """
-        filters = self.api.default_filters.copy()
-        filters.update(filters)
+        request_filters = self.api.default_filters.copy()
+        if filters:
+            request_filters.update(filters)
         return Request(
             base=f"{self.api.base_url}/{self.name}/custom-field-choices/",
             token=self.api.token,
             http_session=self.api.http_session,
-            filters=filters,
+            filters=request_filters,
         ).get()
 
     def config(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -41,6 +41,18 @@ class AppCustomFieldsTestCase(unittest.TestCase):
             self.assertIsInstance(field.get("slug"), str)
             self.assertIn("type", field)
 
+    @patch(
+        "requests.sessions.Session.get",
+        return_value=Response(fixture="extras/custom_fields.json"),
+    )
+    @patch("pynautobot.api.version", "2.0")
+    def test_custom_fields_passes_filters(self, session_get_mock):
+        api = pynautobot.api(HOST, **def_kwargs)
+        api.extras.get_custom_fields(filters={"content_types": "dcim.device"})
+
+        params = session_get_mock.call_args[1].get("params", {})
+        self.assertEqual(params.get("content_types"), "dcim.device")
+
 
 class AppCustomFieldChoicesTestCase(unittest.TestCase):
     """App custom field choices test."""
@@ -67,6 +79,18 @@ class AppCustomFieldChoicesTestCase(unittest.TestCase):
             self.assertIsInstance(choice.get("field"), dict)
             self.assertIsInstance(choice.get("value"), str)
             self.assertIn(choice.get("value"), ("First option", "Second option", "Third option"))
+
+    @patch(
+        "requests.sessions.Session.get",
+        return_value=Response(fixture="extras/custom_field_choices.json"),
+    )
+    @patch("pynautobot.api.version", "2.0")
+    def test_custom_field_choices_passes_filters(self, session_get_mock):
+        api = pynautobot.api(HOST, **def_kwargs)
+        api.extras.get_custom_field_choices(filters={"field": "test_custom_field_2"})
+
+        params = session_get_mock.call_args[1].get("params", {})
+        self.assertEqual(params.get("field"), "test_custom_field_2")
 
 
 class AppConfigTestCase(unittest.TestCase):


### PR DESCRIPTION
# Closes: #389

## What's Changed

`App.get_custom_fields()` and `App.get_custom_field_choices()` both accepted a
`filters` argument that was silently discarded, so callers could never scope these
requests and always got the full unfiltered result set.

The cause was a self-shadowing bug. Each method rebound the `filters` parameter to a
copy of the API default filters and then called `filters.update(filters)` (a no-op
self-update), dropping the caller's value before it reached the `Request`:

```python
# before
filters = self.api.default_filters.copy()
filters.update(filters)
```

The fix merges the caller's filters onto a separate copy of the API defaults, matching
the pattern already used by `Endpoint.filter()` and `Endpoint.get()`:

```python
# after
request_filters = self.api.default_filters.copy()
if filters:
    request_filters.update(filters)
```

The API default filters (`exclude_m2m`, `include`) are preserved, and a caller's filter
of the same key takes precedence.

### Before / After

```python
nb.extras.get_custom_fields(filters={"content_types": "dcim.device"})
```

- **Before:** request sent to `/api/extras/custom-fields/` with no filter params; all custom fields returned.
- **After:** request includes `content_types=dcim.device`; only matching custom fields returned.

### Tests

Added two regression tests (`test_custom_fields_passes_filters`,
`test_custom_field_choices_passes_filters`) asserting the caller's filter is forwarded
as a request query parameter. Both fail against the old code and pass with the fix.

### Documentation

Added a `filters` usage example to both method docstrings. These render into the
auto-generated API reference page (`docs/dev/code_reference/core/app.md`), so the
documented behavior now matches what the code does.
