### PR TITLE
Add example for appending a VLAN ID to a VLAN Group range

### DIFF
--- a/changes/392.documentation
+++ b/changes/392.documentation
@@ -1,0 +1,1 @@
+Added an example showing how to add a VLAN ID to a VLAN Group's range.

--- a/docs/user/basic/examples.md
+++ b/docs/user/basic/examples.md
@@ -211,3 +211,28 @@ This page provides for examples of how to use pynautobot from the community. Wha
     device = nautobot.dcim.devices.get(name="sample-rtr-01", exclude_m2m=False)
 
     ```
+
+=== "Add a VLAN ID to a VLAN Group"
+
+    A VLAN Group's `range` is stored as a plain comma-separated string of individual IDs and ranges (e.g. `1-3,5,10-20`). To add a new VLAN ID, append it to the existing string and call `save()`. Nautobot re-serializes the value on save, collapsing adjacent IDs back into compact ranges.
+
+    ```python
+    import pynautobot
+
+    nautobot = pynautobot.api(url="https://demo.nautobot.com/", token=40*"a")
+
+    # Get the VLAN Group and view its current range
+    vlan_group = nautobot.ipam.vlan_groups.get(name="Test")
+    vlan_group.range
+    # '1-3,5,10-20'
+
+    # Append the new VLAN ID and save
+    vlan_group.range += ",6"
+    vlan_group.save()
+    # True
+
+    # Re-fetch to see Nautobot's re-serialized range
+    vlan_group = nautobot.ipam.vlan_groups.get(name="Test")
+    vlan_group.range
+    # '1-3,5-6,10-20'
+    ```


### PR DESCRIPTION
## What

Adds a new example to the Examples page (`docs/user/basic/examples.md`) showing how to add a VLAN ID to a VLAN Group's `range`.

A VLAN Group's `range` is exposed as a plain comma-separated string (e.g. `1-3,5,10-20`). The example demonstrates appending a new ID to that string and calling `save()`, letting Nautobot re-serialize the value back into compact ranges (`5` and `6` collapse to `5-6`).

## Why

Originated from a community question in the Network to Code Slack. It is not obvious that the `range` field can be updated this way.

## Verification

- `mkdocs build --strict` succeeds (pre-existing autorefs deprecation warnings are unrelated).
- Changelog fragment added: `changes/392.documentation`.

Closes #392