### PR TITLE
Nautobot v3.2 fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         python-version:
           - "3.12"
         nautobot-version:
-          - "3.0"
+          - "stable"
     with:
       runs-on: "${{ inputs.runs-on }}"
       python-version: "${{ matrix.python-version }}"
@@ -73,8 +73,9 @@ jobs:
           - "3.14"
         nautobot-version:
           - "2.4"
-          - "stable"
           - "3.0"
+          - "3.1"
+          - "stable"
     with:
       runs-on: "${{ inputs.runs-on }}"
       python-version: "${{ matrix.python-version }}"

--- a/changes/+ci.housekeeping
+++ b/changes/+ci.housekeeping
@@ -1,0 +1,1 @@
+Added Nautobot v3.1 explicitly to the CI test matrix.

--- a/changes/+test.housekeeping
+++ b/changes/+test.housekeeping
@@ -1,0 +1,1 @@
+Fixed rack integration tests to properly handle new interface ordering in Nautobot v3.2.

--- a/changes/394.fixed
+++ b/changes/394.fixed
@@ -1,0 +1,1 @@
+Fixed cable terminations serialization for Nautobot v3.2.

--- a/pynautobot/models/dcim.py
+++ b/pynautobot/models/dcim.py
@@ -274,6 +274,7 @@ class Cables(Record):
 
     termination_a = Termination
     termination_b = Termination
+    terminations = JsonField
 
 
 class Platforms(Record):

--- a/tests/integration/test_dcim.py
+++ b/tests/integration/test_dcim.py
@@ -110,7 +110,11 @@ class TestSimpleServerRackingAndConnecting:
         server_mgmt_iface = server.api.dcim.interfaces.get(device_id=server.id, mgmt_only=True, has_cable=False)
         assert server_mgmt_iface
 
-        mleaf_iface = mgmt_leaf.api.dcim.interfaces.filter(mgmt_only=False, has_cable=False)[0]
+        mleaf_iface = mgmt_leaf.api.dcim.interfaces.filter(
+            device_id=mgmt_leaf.id,
+            mgmt_only=False,
+            has_cable=False,
+        )[0]
         cable = server.api.dcim.cables.create(
             termination_a_type="dcim.interface",
             termination_a_id=server_mgmt_iface.id,
@@ -120,7 +124,11 @@ class TestSimpleServerRackingAndConnecting:
         )
 
         # connect the data ifaces in a bond
-        server_data_ifaces = server.api.dcim.interfaces.filter(device_id=server.id, mgmt_only=False)[:2]
+        server_data_ifaces = server.api.dcim.interfaces.filter(
+            device_id=server.id,
+            mgmt_only=False,
+            has_cable=False,
+        )[:2]
         assert len(server_data_ifaces) == 2
 
         bond_iface = server.api.dcim.interfaces.create(
@@ -153,7 +161,8 @@ class TestSimpleServerRackingAndConnecting:
             local_iface, cable, remote_iface = trace[0]
 
             assert local_iface.device.id == server.id
-            assert remote_iface.device.id in [dleaf_iface.id] + [data_leaf.id for data_leaf in data_leafs]
+            allowed_remote_devices = [mgmt_leaf.id] + [data_leaf.id for data_leaf in data_leafs]
+            assert remote_iface.device.id in allowed_remote_devices
 
         # check that it's racked properly
         assert server.rack.id == rack.id


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Change 1

Closes: #394

Fixes Cable terminations serialization by setting the `terminations` field to a `JsonField` so it serializes it correctly.

```python
In [5]: cable.terminations
Out[5]:
{'a1': {'id': '48fc3815-1e17-41b8-ab07-0c9143cb7998',
  'object_type': 'dcim.interface',
  'url': 'http://nautobot.example.com/api/dcim/interfaces/48fc3815-1e17-41b8-ab07-0c9143cb7998/'},
 'b1': {'id': 'acbf1f25-4808-4cb2-91c5-3e7c825ed7c4',
  'object_type': 'circuits.circuittermination',
  'url': 'http://nautobot.example.com/api/circuits/circuit-terminations/acbf1f25-4808-4cb2-91c5-3e7c825ed7c4/'}}
```

# Change 2

Fixed tests to properly handle the new interface ordering logic in Nautobot v3.2. These tests are [currently failing in the upstream test CI](https://github.com/nautobot/pynautobot/actions/runs/28733287446/job/85203332618).

# Change 3

Added Nautobot v3.1 explicitly to the CI test matrix. We are already testing it implicitly with the `stable` tag, but (without this change) once that moves to 3.2 we would no longer be testing 3.1.

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests