### PR TITLE
Added the `/render-jinja-template/` API endpoints

### DIFF
--- a/changes/398.added
+++ b/changes/398.added
@@ -1,0 +1,1 @@
+Added the ability to render a Jinja template via the `core` and `ui` app endpoints.

--- a/docs/user/advanced/index.md
+++ b/docs/user/advanced/index.md
@@ -8,5 +8,5 @@ exceptions will be discussed in each section. Following the discussion
 of CRUD operations, other common uses are covered.
 
 
-create read update record session graphql
+create read update record session graphql render_jinja_template
 

--- a/docs/user/advanced/render_jinja_template.md
+++ b/docs/user/advanced/render_jinja_template.md
@@ -1,0 +1,70 @@
+# Rendering a Jinja Template
+
+Nautobot can render a Jinja template server-side and return the result.
+pynautobot exposes this through the `core` app, which is available on the
+`~pynautobot.core.api.Api`{.interpreted-text role="py:class"} object upon
+initialization. The setup is the same as detailed in
+`Creating a pynautobot Instance`{.interpreted-text role="ref"}.
+
+```python
+import os
+
+from pynautobot import api
+
+url = "https://demo.nautobot.com"
+
+# Retrieve token from system environment variable
+# token = os.environ["NAUTOBOT_TOKEN"]
+token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+nautobot = api(url=url, token=token)
+```
+
+## Rendering a Template
+
+The `~pynautobot.core.app.CoreApp.render_jinja_template`{.interpreted-text
+role="py:meth"} method accepts the template to render as `template_code`
+and an optional `context` dictionary of variables. It returns the raw
+response from Nautobot as a dictionary.
+
+```python
+>>> result = nautobot.core.render_jinja_template(
+...     template_code="Hello {{ name }}",
+...     context={"name": "world"},
+... )
+>>> result["rendered_template"]
+'Hello world'
+```
+
+The returned dictionary contains the following keys:
+
+- `rendered_template`: The rendered output as a single string.
+- `rendered_template_lines`: The rendered output split into a list of lines.
+- `template_code`: The template that was submitted.
+- `context`: The context that was submitted.
+
+```python
+>>> result
+{
+    'rendered_template': 'Hello world',
+    'rendered_template_lines': ['Hello world'],
+    'template_code': 'Hello {{ name }}',
+    'context': {'name': 'world'}
+}
+```
+
+## Rendering Without Context
+
+The `context` argument is optional and defaults to an empty dictionary,
+which is useful for templates that do not require any variables.
+
+```python
+>>> result = nautobot.core.render_jinja_template(
+...     template_code="{{ 2 + 2 }}",
+... )
+>>> result["rendered_template"]
+'4'
+```
+
+!!! Tip
+
+    Nautobot's [Jinja2 template rendering](https://docs.nautobot.com/projects/core/en/stable/user-guide/platform-functionality/template-filters/) documentation lists the filters and functions available within templates.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
           - GraphQL: "user/advanced/graphql.md"
           - Read: "user/advanced/read.md"
           - Record: "user/advanced/record.md"
+          - Render Jinja Template: "user/advanced/render_jinja_template.md"
           - Session: "user/advanced/session.md"
           - Update: "user/advanced/update.md"
   - Administrator Guide:

--- a/pynautobot/core/api.py
+++ b/pynautobot/core/api.py
@@ -20,7 +20,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
-from pynautobot.core.app import App, PluginsApp
+from pynautobot.core.app import App, CoreApp, PluginsApp, UiApp
 from pynautobot.core.graphql import GraphQLQuery
 from pynautobot.core.query import Request
 
@@ -51,12 +51,14 @@ class Api:
     Attributes:
         circuits: An instance of the `App` class providing access to Circuits endpoints.
         cloud: An instance of the `App` class providing access to Cloud endpoints.
+        core: An instance of the `App` class providing access to Core endpoints.
         data_validation: An instance of the `App` class providing access to Data Validation endpoints.
         dcim: An instance of the `App` class providing access to DCIM endpoints.
         extras: An instance of the `App` class providing access to Extras endpoints.
         ipam: An instance of the `App` class providing access to IPAM endpoints.
         load_balancers: An instance of the `App` class providing access to Load Balancers endpoints.
         tenancy: An instance of the `App` class providing access to Tenancy endpoints.
+        ui: An instance of the `App` class providing access to UI endpoints.
         users: An instance of the `App` class providing access to User endpoints.
         virtualization: An instance of the `App` class providing access to Virtualization endpoints.
         vpn: An instance of the `App` class providing access to VPN endpoints.
@@ -123,12 +125,14 @@ class Api:
 
         self.circuits = App(self, "circuits")
         self.cloud = App(self, "cloud")
+        self.core = CoreApp(self, "core")
         self.data_validation = App(self, "data-validation")
         self.dcim = App(self, "dcim")
         self.extras = App(self, "extras")
         self.ipam = App(self, "ipam")
         self.load_balancers = App(self, "load-balancers")
         self.tenancy = App(self, "tenancy")
+        self.ui = UiApp(self, "ui")
         self.users = App(self, "users")
         self.virtualization = App(self, "virtualization")
         self.vpn = App(self, "vpn")

--- a/pynautobot/core/app.py
+++ b/pynautobot/core/app.py
@@ -237,6 +237,68 @@ class App:
         ).get()
 
 
+class CoreApp(App):
+    """Represents the Nautobot ``core`` app.
+
+    In addition to the generic `App` endpoint access, this exposes a dedicated
+    helper for the ``render-jinja-template`` endpoint.
+    """
+
+    def render_jinja_template(self, template_code, context=None, api_version=None):
+        """Render a Jinja template server-side via Nautobot.
+
+        Args:
+            template_code (str): The Jinja template to render.
+            context (dict, optional): Context variables for the template. Defaults to ``{}``.
+            api_version (str, optional): Override the default or globally-set Nautobot REST API
+                version for this single request.
+
+        Returns:
+            (dict): Raw response containing ``rendered_template``, ``rendered_template_lines``,
+                ``template_code``, and ``context``.
+
+        Raises:
+            RequestError: If the template fails to render.
+
+        Examples:
+            >>> nb.core.render_jinja_template(
+            ...     template_code="Hello {{ name }}",
+            ...     context={"name": "world"},
+            ... )
+            {'rendered_template': 'Hello world',
+             'rendered_template_lines': ['Hello world'],
+             'template_code': 'Hello {{ name }}',
+             'context': {'name': 'world'}}
+        """
+        api_version = api_version or self.api.api_version
+        return Request(
+            base=f"{self.api.base_url}/{self.name}/render-jinja-template/",
+            token=self.api.token,
+            http_session=self.api.http_session,
+            api_version=api_version,
+        ).post({"template_code": template_code, "context": context or {}})
+
+
+class UiApp(App):
+    """Represents the Nautobot ``ui`` app."""
+
+    @property
+    def core(self):
+        """Access ``core`` endpoints nested under ``ui`` (e.g. render-jinja-template).
+
+        Returns:
+            (CoreApp): A `CoreApp` bound to the ``ui/core`` path.
+
+        Examples:
+            >>> nb.ui.core.render_jinja_template(
+            ...     template_code="Hello {{ name }}",
+            ...     context={"name": "world"},
+            ... )
+            {'rendered_template': 'Hello world', ...}
+        """
+        return CoreApp(self.api, "ui/core")
+
+
 class PluginsApp:
     """Add plugins to the URL path.
 

--- a/tests/fixtures/core/render_jinja_template.json
+++ b/tests/fixtures/core/render_jinja_template.json
@@ -1,0 +1,6 @@
+{
+    "rendered_template": "Hello world",
+    "rendered_template_lines": ["Hello world"],
+    "template_code": "Hello {{ name }}",
+    "context": {"name": "world"}
+}

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -1,0 +1,33 @@
+"""Core and UI app integration tests."""
+
+import pytest
+from packaging import version
+
+
+class TestRenderJinjaTemplate:
+    """Verify rendering a Jinja template via the core and ui apps."""
+
+    min_version = "2.4"
+    template_code = "Hello {{ name }}"
+    context = {"name": "world"}
+
+    @pytest.fixture
+    def skipif_version(self, nb_status):
+        """Skip the test if the Nautobot version is less than the minimum version."""
+        nautobot_version = nb_status.get("nautobot-version")
+        if version.parse(nautobot_version) < version.parse(self.min_version):
+            pytest.skip(f"render-jinja-template is only in Nautobot {self.min_version}+")
+
+        return nautobot_version
+
+    def test_core_render_jinja_template(self, skipif_version, nb_client):
+        """Render a simple template via the core app."""
+        assert skipif_version
+        result = nb_client.core.render_jinja_template(template_code=self.template_code, context=self.context)
+        assert result["rendered_template"] == "Hello world"
+
+    def test_ui_render_jinja_template(self, skipif_version, nb_client):
+        """Render a simple template via the ui app (ui/core/render-jinja-template/)."""
+        assert skipif_version
+        result = nb_client.ui.core.render_jinja_template(template_code=self.template_code, context=self.context)
+        assert result["rendered_template"] == "Hello world"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -149,6 +149,67 @@ class AppIncludeFiltersTestCase(unittest.TestCase):
         self.assertEqual(api.default_filters["include"], "config_context,computed_fields")
 
 
+class RenderJinjaTemplateTestCase(unittest.TestCase):
+    """Render Jinja template test for the core and ui apps."""
+
+    template_code = "Hello {{ name }}"
+    context = {"name": "world"}
+
+    @patch(
+        "requests.sessions.Session.post",
+        return_value=Response(fixture="core/render_jinja_template.json"),
+    )
+    @patch("pynautobot.api.version", "2.0")
+    def test_core_render_jinja_template(self, session_post_mock):
+        api = pynautobot.api(HOST, **def_kwargs)
+        result = api.core.render_jinja_template(template_code=self.template_code, context=self.context)
+
+        session_post_mock.assert_called_once()
+        expect_url = f"{api.base_url}/core/render-jinja-template/"
+        url_passed_in_args = expect_url in session_post_mock.call_args[0]
+        url_passed_in_kwargs = expect_url == session_post_mock.call_args[1].get("url")
+        self.assertTrue(url_passed_in_args or url_passed_in_kwargs)
+
+        body = session_post_mock.call_args[1].get("json")
+        self.assertEqual(body, {"template_code": self.template_code, "context": self.context})
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["rendered_template"], "Hello world")
+
+    @patch(
+        "requests.sessions.Session.post",
+        return_value=Response(fixture="core/render_jinja_template.json"),
+    )
+    @patch("pynautobot.api.version", "2.0")
+    def test_ui_render_jinja_template(self, session_post_mock):
+        api = pynautobot.api(HOST, **def_kwargs)
+        result = api.ui.core.render_jinja_template(template_code=self.template_code, context=self.context)
+
+        session_post_mock.assert_called_once()
+        expect_url = f"{api.base_url}/ui/core/render-jinja-template/"
+        url_passed_in_args = expect_url in session_post_mock.call_args[0]
+        url_passed_in_kwargs = expect_url == session_post_mock.call_args[1].get("url")
+        self.assertTrue(url_passed_in_args or url_passed_in_kwargs)
+
+        body = session_post_mock.call_args[1].get("json")
+        self.assertEqual(body, {"template_code": self.template_code, "context": self.context})
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["rendered_template"], "Hello world")
+
+    @patch(
+        "requests.sessions.Session.post",
+        return_value=Response(fixture="core/render_jinja_template.json"),
+    )
+    @patch("pynautobot.api.version", "2.0")
+    def test_render_jinja_template_defaults_empty_context(self, session_post_mock):
+        api = pynautobot.api(HOST, **def_kwargs)
+        api.core.render_jinja_template(template_code=self.template_code)
+
+        body = session_post_mock.call_args[1].get("json")
+        self.assertEqual(body, {"template_code": self.template_code, "context": {}})
+
+
 class PluginAppCustomChoicesTestCase(unittest.TestCase):
     """Plugin app custom choices test."""
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #398

## What's Changed

This PR adds both the `core` and `ui` top level URI path elements to automatically expose any of those app endpoints. In addition, I have created a helper method specifically for the existing `/render-jinja-template/` endpoint on both apps.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [N/A] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [N/A] Outline Remaining Work, Constraints from Design
